### PR TITLE
chore: MIRAI 스킬 4종 + skill-activation-prompt 훅 이식 (#11)

### DIFF
--- a/.claude/hooks/.ai.md
+++ b/.claude/hooks/.ai.md
@@ -1,19 +1,30 @@
 # .claude/hooks/
 
 ## 목적
-Claude Code PostToolUse 훅 스크립트 모음.
-도구 실행 결과(`tool_response`)에서 민감 정보를 탐지하고 Claude에게 경고를 전달한다.
+Claude Code 훅 스크립트 모음. 도구 실행 결과에서 민감 정보를 탐지하고, 사용자 프롬프트에서 관련 스킬을 자동 제안한다.
 
 ## 파일
 - `secret-filter.sh` — 시크릿 패턴 탐지 훅 (API 키, 토큰, 패스워드 등)
+- `skill-activation-prompt.sh` — 스킬 자동 제안 훅 (Bash 래퍼, tsx 가드 포함)
+- `skill-activation-prompt.ts` — 스킬 매칭 로직 (키워드/의도 패턴 매칭, 우선순위 정렬)
 
 ## 훅 동작
+
+### secret-filter (PostToolUse)
 - 이벤트: `PostToolUse` (모든 도구 실행 후)
 - 탐지 시: `hookSpecificOutput.additionalContext` JSON 출력 + `~/.claude/security.log` 기록
 - 미탐지 시: 빈 출력, exit 0
 - 항상 exit 0 (PostToolUse는 차단 불가)
 
+### skill-activation-prompt (UserPromptSubmit)
+- 이벤트: `UserPromptSubmit` (사용자 프롬프트 제출 시)
+- `.claude/skills/skill-rules.json`에서 스킬 트리거 규칙 로드
+- 프롬프트를 키워드 및 의도 패턴(regex)과 매칭
+- 매칭된 스킬을 우선순위(critical > high > medium > low) 순으로 출력
+- tsx 미설치 시 graceful exit (경고 메시지 출력 후 통과)
+
 ## 규칙
 - 실제 시크릿 값은 로그에 기록하지 않음
-- Python3 미설치 시 graceful exit (경고 없이 통과)
-- 패턴 추가 시 스크립트 내 SECRET_PATTERNS 배열에 추가
+- Python3 미설치 시 secret-filter graceful exit
+- tsx 미설치 시 skill-activation-prompt graceful exit
+- 패턴 추가: secret-filter는 스크립트 내 SECRET_PATTERNS, skill-activation은 `skill-rules.json`

--- a/.claude/hooks/skill-activation-prompt.sh
+++ b/.claude/hooks/skill-activation-prompt.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# tsx 가드: npx 또는 tsx가 없으면 graceful exit (프로세스 스폰 없이 경로 체크만)
+command -v npx >/dev/null 2>&1 || { echo "npx not found, skipping skill activation"; exit 0; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+cat | npx tsx skill-activation-prompt.ts

--- a/.claude/hooks/skill-activation-prompt.ts
+++ b/.claude/hooks/skill-activation-prompt.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+interface HookInput {
+    prompt: string;
+}
+
+interface PromptTriggers {
+    keywords?: string[];
+    intentPatterns?: string[];
+}
+
+interface SkillRule {
+    type: 'guardrail' | 'domain';
+    enforcement: 'block' | 'suggest' | 'warn';
+    priority: 'critical' | 'high' | 'medium' | 'low';
+    description?: string;
+    promptTriggers?: PromptTriggers;
+}
+
+interface SkillRules {
+    version: string;
+    skills: Record<string, SkillRule>;
+}
+
+interface MatchedSkill {
+    name: string;
+    matchType: 'keyword' | 'intent';
+    config: SkillRule;
+}
+
+function findRulesPath(): string | null {
+    const projectDir = process.env.CLAUDE_PROJECT_DIR;
+    if (projectDir) {
+        const p = join(projectDir, '.claude', 'skills', 'skill-rules.json');
+        if (existsSync(p)) return p;
+    }
+
+    const cwdPath = join(process.cwd(), '..', 'skills', 'skill-rules.json');
+    if (existsSync(cwdPath)) return cwdPath;
+
+    return null;
+}
+
+function sortPriority(matches: MatchedSkill[]): MatchedSkill[] {
+    const rank = { critical: 0, high: 1, medium: 2, low: 3 } as const;
+    return [...matches].sort((a, b) => rank[a.config.priority] - rank[b.config.priority]);
+}
+
+async function main() {
+    try {
+        const input = readFileSync(0, 'utf-8');
+        const data: HookInput = JSON.parse(input);
+        const prompt = (data.prompt || '').toLowerCase();
+        if (!prompt) process.exit(0);
+
+        const rulesPath = findRulesPath();
+        if (!rulesPath) process.exit(0);
+        const rules: SkillRules = JSON.parse(readFileSync(rulesPath, 'utf-8'));
+
+        const matchedSkills: MatchedSkill[] = [];
+
+        for (const [skillName, config] of Object.entries(rules.skills)) {
+            const triggers = config.promptTriggers;
+            if (!triggers) continue;
+
+            if (triggers.keywords?.some(kw => prompt.includes(kw.toLowerCase()))) {
+                matchedSkills.push({ name: skillName, matchType: 'keyword', config });
+                continue;
+            }
+
+            if (triggers.intentPatterns?.some(pattern => new RegExp(pattern, 'i').test(prompt))) {
+                matchedSkills.push({ name: skillName, matchType: 'intent', config });
+            }
+        }
+
+        if (matchedSkills.length === 0) process.exit(0);
+
+        const ordered = sortPriority(matchedSkills);
+        let output = '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n';
+        output += 'SKILL ACTIVATION CHECK\n';
+        output += '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n';
+
+        for (const match of ordered) {
+            output += `- ${match.name}`;
+            if (match.config.description) {
+                output += `: ${match.config.description}`;
+            }
+            output += '\n';
+        }
+
+        output += '\nACTION: relevant local project skills are available.\n';
+        output += '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n';
+        console.log(output);
+        process.exit(0);
+    } catch (e) {
+        console.error('skill-activation-prompt error:', e);
+        process.exit(0);
+    }
+}
+
+main().catch((e) => { console.error('skill-activation-prompt error:', e); process.exit(0); });

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,16 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/skill-activation-prompt.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/.ai.md
+++ b/.claude/skills/.ai.md
@@ -1,0 +1,34 @@
+# .claude/skills/ — 스킬 디렉토리
+
+## 목적
+Claude Code가 사용자 프롬프트의 키워드/의도를 감지하여 관련 스킬을 자동 제안하는 로컬 스킬 시스템.
+
+## 구조
+```
+skills/
+├── skill-rules.json                  # 스킬 트리거 규칙 (키워드, 의도 패턴, 우선순위)
+├── database-schema-design/           # Snowflake 스키마 설계 스킬
+│   └── SKILL.md
+├── git-commit/                       # Conventional Commits 스킬
+│   └── SKILL.md
+├── test-driven-development/          # TDD Red-Green-Refactor 스킬
+│   ├── SKILL.md
+│   └── testing-anti-patterns.md
+└── security-best-practices/          # Snowflake 보안 스킬
+    └── SKILL.md
+```
+
+## 작동 원리
+1. 사용자가 프롬프트를 입력하면 `UserPromptSubmit` 훅이 발동
+2. `skill-activation-prompt.ts`가 `skill-rules.json`의 키워드/의도 패턴과 매칭
+3. 매칭된 스킬을 우선순위 순으로 제안
+
+## 스킬 추가 방법
+1. `skills/` 하위에 새 디렉토리 생성
+2. `SKILL.md` 작성 (frontmatter에 name, description 필수)
+3. `skill-rules.json`에 트리거 규칙 추가
+4. `.ai.md` 작성
+
+## 참고
+- 트리거 규칙: `skill-rules.json` 참조
+- 훅 스크립트: `.claude/hooks/skill-activation-prompt.sh` + `.ts`

--- a/.claude/skills/database-schema-design/.ai.md
+++ b/.claude/skills/database-schema-design/.ai.md
@@ -1,0 +1,18 @@
+# database-schema-design 스킬
+
+## 목적
+Snowflake 데이터베이스 스키마를 설계하고 최적화하는 도메인 스킬.
+
+## 파일 구조
+- `SKILL.md` — 스킬 본문 (Snowflake 전용 스키마 설계 가이드)
+
+## 역할
+- Snowflake 3-tier 네임스페이스 (DATABASE > SCHEMA > TABLE) 설계
+- Snowflake 전용 데이터 타입 활용 (VARIANT, OBJECT, ARRAY, TIMESTAMP_LTZ 등)
+- CLUSTER BY, Micro-partition pruning 최적화
+- COPY INTO, Stage, Snowpipe 데이터 로딩 파이프라인 설계
+- Time Travel, Streams, Tasks, Dynamic Tables 활용
+- ERD 다이어그램 (Mermaid) 생성
+
+## 트리거 키워드
+`스키마`, `schema`, `snowflake`, `variant`, `cluster by`, `copy into`, `stage`, `time travel`, `데이터 모델링`, `ERD`

--- a/.claude/skills/database-schema-design/SKILL.md
+++ b/.claude/skills/database-schema-design/SKILL.md
@@ -1,0 +1,482 @@
+---
+name: database-schema-design
+description: Design and optimize Snowflake database schemas. Use when creating databases, designing tables, defining relationships, clustering strategies, or data loading pipelines. Handles Snowflake SQL, semi-structured data (VARIANT/OBJECT/ARRAY), Time Travel, Streams, Tasks, and Dynamic Tables.
+metadata:
+  tags: database, schema, Snowflake, SQL, VARIANT, clustering, data-loading
+  platforms: Claude
+---
+
+
+# Snowflake Database Schema Design
+
+
+## When to use this skill
+
+- **New Project**: Snowflake 데이터베이스 스키마 설계
+- **Schema Refactoring**: 성능 또는 확장성을 위한 기존 스키마 재설계
+- **Relationship Definition**: 테이블 간 관계 구현
+- **Data Loading**: COPY INTO, Stage, Pipe를 통한 데이터 적재 파이프라인 설계
+- **Performance Issues**: Clustering, Micro-partition pruning 최적화
+
+## Input Format
+
+### Required Information
+- **Domain Description**: 어떤 데이터를 저장할 것인가 (예: 교육 플랫폼, 분석 파이프라인)
+- **Key Entities**: 핵심 데이터 객체 (예: Student, Course, Enrollment)
+
+### Optional Information
+- **Expected Data Volume**: Small (<1M rows), Medium (1M-100M), Large (>100M) (default: Medium)
+- **Read/Write Pattern**: Batch load + analytics, Streaming, Mixed (default: Batch + analytics)
+- **Semi-structured Data**: JSON/Parquet/Avro 데이터 포함 여부 (default: false)
+- **Time Travel Requirements**: 보존 기간 (default: 1 day, max 90 days for Enterprise)
+- **Multi-cluster Warehouse**: 동시성 요구사항 (default: false)
+
+### Input Example
+
+```
+Design a Snowflake database for an education analytics platform:
+- Entities: Student, Course, Enrollment, Assessment, LearningLog
+- Relationships:
+  - A Student can enroll in multiple Courses (N:M)
+  - An Assessment belongs to a Course
+  - LearningLog stores JSON activity data per Student
+- Expected data: 500K students, 10M learning logs/month
+- Batch load from S3 daily + real-time streaming via Snowpipe
+```
+
+## Instructions
+
+### Step 1: Define Database and Schema Structure
+
+Snowflake는 `DATABASE > SCHEMA > TABLE` 3-tier 네임스페이스를 사용한다.
+
+**Tasks**:
+- 도메인별 Database 분리 (RAW, STAGING, ANALYTICS 등)
+- Schema로 논리적 그룹핑
+- 네이밍 컨벤션 확립 (UPPER_SNAKE_CASE 권장)
+
+**Example** (Education Platform):
+```sql
+-- Database 생성
+CREATE DATABASE IF NOT EXISTS EDU_ANALYTICS;
+
+-- Schema 분리
+CREATE SCHEMA IF NOT EXISTS EDU_ANALYTICS.RAW;        -- 원본 데이터
+CREATE SCHEMA IF NOT EXISTS EDU_ANALYTICS.STAGING;    -- 변환 중간 단계
+CREATE SCHEMA IF NOT EXISTS EDU_ANALYTICS.ANALYTICS;  -- 분석용 최종 테이블
+CREATE SCHEMA IF NOT EXISTS EDU_ANALYTICS.COMMON;     -- 공통 참조 테이블
+```
+
+### Step 2: Define Entities and Data Types
+
+Snowflake 전용 데이터 타입을 활용하여 엔티티를 정의한다.
+
+**Snowflake 주요 데이터 타입**:
+| 타입 | 용도 |
+|------|------|
+| `NUMBER(p,s)` | 정수/소수 (최대 38자리) |
+| `VARCHAR(n)` | 가변 문자열 (최대 16MB) |
+| `TIMESTAMP_LTZ` | 로컬 타임존 포함 타임스탬프 |
+| `TIMESTAMP_NTZ` | 타임존 없는 타임스탬프 |
+| `TIMESTAMP_TZ` | 타임존 오프셋 포함 타임스탬프 |
+| `VARIANT` | 반정형 데이터 (JSON, Avro, Parquet) |
+| `OBJECT` | 키-값 쌍 (VARIANT 하위) |
+| `ARRAY` | 배열 (VARIANT 하위) |
+| `GEOGRAPHY` | 지리 공간 데이터 |
+| `BOOLEAN` | 참/거짓 |
+| `DATE` | 날짜 |
+
+**Example**:
+```sql
+CREATE TABLE EDU_ANALYTICS.ANALYTICS.STUDENTS (
+    STUDENT_ID NUMBER AUTOINCREMENT PRIMARY KEY,
+    EMAIL VARCHAR(255) NOT NULL,
+    NAME VARCHAR(100) NOT NULL,
+    PROFILE VARIANT,                    -- JSON 프로필 데이터
+    ENROLLMENT_DATE DATE DEFAULT CURRENT_DATE(),
+    CREATED_AT TIMESTAMP_LTZ DEFAULT CURRENT_TIMESTAMP(),
+    UPDATED_AT TIMESTAMP_LTZ DEFAULT CURRENT_TIMESTAMP()
+);
+
+CREATE TABLE EDU_ANALYTICS.ANALYTICS.COURSES (
+    COURSE_ID NUMBER AUTOINCREMENT PRIMARY KEY,
+    COURSE_CODE VARCHAR(20) NOT NULL,
+    TITLE VARCHAR(255) NOT NULL,
+    DESCRIPTION VARCHAR(5000),
+    METADATA VARIANT,                   -- 과목 메타데이터 (태그, 카테고리 등)
+    CREDITS NUMBER(2,0) DEFAULT 3,
+    IS_ACTIVE BOOLEAN DEFAULT TRUE,
+    CREATED_AT TIMESTAMP_LTZ DEFAULT CURRENT_TIMESTAMP()
+);
+
+CREATE TABLE EDU_ANALYTICS.ANALYTICS.ENROLLMENTS (
+    ENROLLMENT_ID NUMBER AUTOINCREMENT PRIMARY KEY,
+    STUDENT_ID NUMBER NOT NULL REFERENCES STUDENTS(STUDENT_ID),
+    COURSE_ID NUMBER NOT NULL REFERENCES COURSES(COURSE_ID),
+    ENROLLED_AT TIMESTAMP_LTZ DEFAULT CURRENT_TIMESTAMP(),
+    STATUS VARCHAR(20) DEFAULT 'ACTIVE',  -- ACTIVE, COMPLETED, DROPPED
+    GRADE VARCHAR(2),
+    UNIQUE (STUDENT_ID, COURSE_ID)
+);
+
+CREATE TABLE EDU_ANALYTICS.ANALYTICS.LEARNING_LOGS (
+    LOG_ID NUMBER AUTOINCREMENT,
+    STUDENT_ID NUMBER NOT NULL,
+    COURSE_ID NUMBER NOT NULL,
+    ACTIVITY_DATA VARIANT,              -- JSON 활동 로그
+    EVENT_TYPE VARCHAR(50),
+    EVENT_TIMESTAMP TIMESTAMP_LTZ DEFAULT CURRENT_TIMESTAMP(),
+    INGESTED_AT TIMESTAMP_LTZ DEFAULT CURRENT_TIMESTAMP()
+);
+```
+
+### Step 3: Design Clustering and Partitioning
+
+Snowflake는 자동 Micro-partitioning을 사용하지만, `CLUSTER BY`로 쿼리 성능을 최적화할 수 있다.
+
+**Tasks**:
+- 대용량 테이블에 `CLUSTER BY` 설정
+- 자주 필터링하는 컬럼을 클러스터링 키로 선택
+- Micro-partition pruning 효율성 확인
+
+**Clustering 가이드라인**:
+- 100M+ 행 테이블에서 효과적
+- WHERE 절에 자주 사용되는 컬럼 선택
+- 카디널리티가 적절한 컬럼 (너무 높거나 낮으면 비효율)
+- 최대 3-4개 컬럼 권장
+
+**Example**:
+```sql
+-- 학습 로그: 날짜와 학생 기준으로 자주 조회
+ALTER TABLE EDU_ANALYTICS.ANALYTICS.LEARNING_LOGS
+    CLUSTER BY (EVENT_TIMESTAMP::DATE, STUDENT_ID);
+
+-- 클러스터링 상태 확인
+SELECT SYSTEM$CLUSTERING_INFORMATION('EDU_ANALYTICS.ANALYTICS.LEARNING_LOGS');
+
+-- 클러스터링 깊이 확인
+SELECT SYSTEM$CLUSTERING_DEPTH('EDU_ANALYTICS.ANALYTICS.LEARNING_LOGS');
+```
+
+**Table Types**:
+```sql
+-- Transient Table: Time Travel 1일, Fail-safe 없음 (임시 데이터)
+CREATE TRANSIENT TABLE EDU_ANALYTICS.STAGING.TEMP_IMPORT (
+    RAW_DATA VARIANT,
+    LOADED_AT TIMESTAMP_LTZ DEFAULT CURRENT_TIMESTAMP()
+);
+
+-- Temporary Table: 세션 종료 시 자동 삭제
+CREATE TEMPORARY TABLE SESSION_CACHE (
+    KEY VARCHAR(100),
+    VALUE VARIANT
+);
+```
+
+### Step 4: Set Up Data Loading Pipeline
+
+Snowflake의 데이터 로딩 메커니즘을 설계한다.
+
+**Tasks**:
+- External/Internal Stage 설정
+- File Format 정의
+- COPY INTO 또는 Snowpipe 구성
+
+**Example**:
+```sql
+-- File Format 정의
+CREATE FILE FORMAT EDU_ANALYTICS.RAW.JSON_FORMAT
+    TYPE = 'JSON'
+    STRIP_OUTER_ARRAY = TRUE
+    COMPRESSION = 'AUTO';
+
+CREATE FILE FORMAT EDU_ANALYTICS.RAW.CSV_FORMAT
+    TYPE = 'CSV'
+    FIELD_DELIMITER = ','
+    SKIP_HEADER = 1
+    NULL_IF = ('NULL', 'null', '')
+    COMPRESSION = 'AUTO';
+
+-- External Stage (S3)
+CREATE STAGE EDU_ANALYTICS.RAW.S3_STAGE
+    URL = 's3://edu-data-bucket/raw/'
+    STORAGE_INTEGRATION = S3_INTEGRATION
+    FILE_FORMAT = EDU_ANALYTICS.RAW.JSON_FORMAT;
+
+-- COPY INTO로 배치 로딩
+COPY INTO EDU_ANALYTICS.RAW.LEARNING_LOGS_RAW
+    FROM @EDU_ANALYTICS.RAW.S3_STAGE/learning_logs/
+    FILE_FORMAT = EDU_ANALYTICS.RAW.JSON_FORMAT
+    PATTERN = '.*\\.json\\.gz'
+    ON_ERROR = 'CONTINUE';
+
+-- Snowpipe (자동 연속 로딩)
+CREATE PIPE EDU_ANALYTICS.RAW.LEARNING_LOGS_PIPE
+    AUTO_INGEST = TRUE
+    AS
+    COPY INTO EDU_ANALYTICS.RAW.LEARNING_LOGS_RAW
+        FROM @EDU_ANALYTICS.RAW.S3_STAGE/learning_logs/
+        FILE_FORMAT = EDU_ANALYTICS.RAW.JSON_FORMAT;
+```
+
+### Step 5: Configure Time Travel and Data Protection
+
+**Tasks**:
+- Time Travel 보존 기간 설정
+- 중요 테이블 보호 전략
+
+**Example**:
+```sql
+-- 분석 테이블: 7일 Time Travel
+ALTER TABLE EDU_ANALYTICS.ANALYTICS.STUDENTS
+    SET DATA_RETENTION_TIME_IN_DAYS = 7;
+
+ALTER TABLE EDU_ANALYTICS.ANALYTICS.ENROLLMENTS
+    SET DATA_RETENTION_TIME_IN_DAYS = 7;
+
+-- Time Travel로 과거 데이터 조회
+SELECT * FROM EDU_ANALYTICS.ANALYTICS.STUDENTS
+    AT (OFFSET => -3600);  -- 1시간 전
+
+SELECT * FROM EDU_ANALYTICS.ANALYTICS.STUDENTS
+    BEFORE (TIMESTAMP => '2024-01-15 10:00:00'::TIMESTAMP_LTZ);
+
+-- 실수로 삭제한 테이블 복구
+UNDROP TABLE EDU_ANALYTICS.ANALYTICS.STUDENTS;
+```
+
+### Step 6: Design Streams and Tasks (CDC Pipeline)
+
+변경 데이터 캡처(CDC)와 자동화된 데이터 변환을 설계한다.
+
+**Example**:
+```sql
+-- Stream: RAW 테이블의 변경사항 추적
+CREATE STREAM EDU_ANALYTICS.STAGING.LEARNING_LOGS_STREAM
+    ON TABLE EDU_ANALYTICS.RAW.LEARNING_LOGS_RAW;
+
+-- Task: Stream 데이터를 주기적으로 Analytics로 변환
+CREATE TASK EDU_ANALYTICS.STAGING.TRANSFORM_LEARNING_LOGS
+    WAREHOUSE = TRANSFORM_WH
+    SCHEDULE = 'USING CRON 0 * * * * UTC'  -- 매시간
+    WHEN SYSTEM$STREAM_HAS_DATA('EDU_ANALYTICS.STAGING.LEARNING_LOGS_STREAM')
+AS
+    INSERT INTO EDU_ANALYTICS.ANALYTICS.LEARNING_LOGS (
+        STUDENT_ID, COURSE_ID, ACTIVITY_DATA, EVENT_TYPE, EVENT_TIMESTAMP
+    )
+    SELECT
+        RAW_DATA:student_id::NUMBER,
+        RAW_DATA:course_id::NUMBER,
+        RAW_DATA,
+        RAW_DATA:event_type::VARCHAR,
+        RAW_DATA:event_timestamp::TIMESTAMP_LTZ
+    FROM EDU_ANALYTICS.STAGING.LEARNING_LOGS_STREAM
+    WHERE METADATA$ACTION = 'INSERT';
+
+-- Task 활성화
+ALTER TASK EDU_ANALYTICS.STAGING.TRANSFORM_LEARNING_LOGS RESUME;
+
+-- Dynamic Table (선언적 파이프라인)
+CREATE DYNAMIC TABLE EDU_ANALYTICS.ANALYTICS.STUDENT_COURSE_SUMMARY
+    TARGET_LAG = '1 hour'
+    WAREHOUSE = TRANSFORM_WH
+AS
+    SELECT
+        s.STUDENT_ID,
+        s.NAME,
+        COUNT(DISTINCT e.COURSE_ID) AS ENROLLED_COURSES,
+        COUNT(l.LOG_ID) AS TOTAL_ACTIVITIES,
+        MAX(l.EVENT_TIMESTAMP) AS LAST_ACTIVITY
+    FROM EDU_ANALYTICS.ANALYTICS.STUDENTS s
+    LEFT JOIN EDU_ANALYTICS.ANALYTICS.ENROLLMENTS e
+        ON s.STUDENT_ID = e.STUDENT_ID
+    LEFT JOIN EDU_ANALYTICS.ANALYTICS.LEARNING_LOGS l
+        ON s.STUDENT_ID = l.STUDENT_ID
+    GROUP BY s.STUDENT_ID, s.NAME;
+```
+
+## Output Format
+
+### Basic Structure
+
+```
+database/
+├── 01_databases_and_schemas.sql    -- DB/Schema 생성
+├── 02_tables.sql                   -- 테이블 DDL
+├── 03_clustering.sql               -- 클러스터링 설정
+├── 04_stages_and_formats.sql       -- Stage, File Format
+├── 05_pipes.sql                    -- Snowpipe 설정
+├── 06_streams_and_tasks.sql        -- CDC 파이프라인
+├── 07_dynamic_tables.sql           -- Dynamic Tables
+└── docs/
+    └── ERD.md                      -- Mermaid ERD 다이어그램
+```
+
+### ERD Diagram (Mermaid Format)
+
+```mermaid
+erDiagram
+    STUDENTS ||--o{ ENROLLMENTS : enrolls
+    COURSES ||--o{ ENROLLMENTS : "enrolled in"
+    STUDENTS ||--o{ LEARNING_LOGS : generates
+    COURSES ||--o{ LEARNING_LOGS : "logged for"
+    COURSES ||--o{ ASSESSMENTS : has
+
+    STUDENTS {
+        number STUDENT_ID PK
+        varchar EMAIL
+        varchar NAME
+        variant PROFILE
+    }
+
+    COURSES {
+        number COURSE_ID PK
+        varchar COURSE_CODE
+        varchar TITLE
+        variant METADATA
+    }
+
+    ENROLLMENTS {
+        number ENROLLMENT_ID PK
+        number STUDENT_ID FK
+        number COURSE_ID FK
+        varchar STATUS
+    }
+```
+
+## Constraints
+
+### Mandatory Rules (MUST)
+
+1. **Primary Key Required**: 모든 테이블에 Primary Key 정의
+   - Snowflake PK는 참조 무결성을 강제하지 않지만, 쿼리 최적화에 활용됨
+   - 옵티마이저 힌트로 작동
+
+2. **네임스페이스 명시**: 항상 `DATABASE.SCHEMA.TABLE` 전체 경로 사용
+   - 모호성 방지
+   - 환경 간 이식성
+
+3. **VARIANT 데이터 구조 문서화**: 반정형 컬럼의 예상 스키마를 주석으로 기술
+   - VARIANT는 스키마리스이므로, 예상 구조를 코드로 문서화
+
+### Prohibited Actions (MUST NOT)
+
+1. **과도한 클러스터링**: 소규모 테이블(<100M 행)에 불필요한 CLUSTER BY 적용 금지
+   - 자동 클러스터링 크레딧 낭비
+   - Micro-partition이 자동 관리하는 범위 내
+
+2. **VARIANT 남용**: 정형 데이터를 VARIANT에 저장하지 않음
+   - 쿼리 성능 저하
+   - 타입 안전성 상실
+
+3. **민감 데이터 평문 저장**: 개인정보, 비밀번호 등을 암호화 없이 저장 금지
+   - Masking Policy 또는 External Tokenization 활용
+
+### Performance Rules
+
+- **결과 캐시 활용**: 동일 쿼리 반복 시 `RESULT_USE_CACHING = TRUE` 확인
+- **Warehouse 적정 크기**: 쿼리 패턴에 맞는 Warehouse 크기 선택
+- **Zero-copy Cloning**: 개발/테스트 환경에 `CREATE TABLE ... CLONE` 활용
+
+## Best Practices
+
+### Quality Improvement
+
+1. **UPPER_SNAKE_CASE Naming**: Snowflake는 기본적으로 대문자 식별자 사용
+   - `STUDENTS`, `COURSE_ID`, `CREATED_AT`
+   - 따옴표 없이 일관성 유지
+
+2. **Timestamps에 TIMESTAMP_LTZ 사용**: 글로벌 사용자 대상 시 타임존 처리 필수
+   - `CREATED_AT TIMESTAMP_LTZ DEFAULT CURRENT_TIMESTAMP()`
+
+3. **Zero-Copy Cloning 활용**: 개발/테스트 환경 빠른 구성
+   ```sql
+   CREATE DATABASE EDU_ANALYTICS_DEV CLONE EDU_ANALYTICS;
+   ```
+
+### Performance Optimization
+
+- **Materialized Views**: 반복 집계 쿼리 최적화
+  ```sql
+  CREATE MATERIALIZED VIEW EDU_ANALYTICS.ANALYTICS.MV_DAILY_ACTIVITY
+  AS
+  SELECT
+      EVENT_TIMESTAMP::DATE AS ACTIVITY_DATE,
+      COURSE_ID,
+      COUNT(*) AS EVENT_COUNT
+  FROM EDU_ANALYTICS.ANALYTICS.LEARNING_LOGS
+  GROUP BY 1, 2;
+  ```
+
+- **Search Optimization Service**: 포인트 쿼리 가속
+  ```sql
+  ALTER TABLE EDU_ANALYTICS.ANALYTICS.STUDENTS
+      ADD SEARCH OPTIMIZATION ON EQUALITY(EMAIL);
+  ```
+
+## Common Issues
+
+### Issue 1: VARIANT 쿼리 성능 저하
+
+**Symptom**: VARIANT 컬럼 쿼리가 느림
+
+**Cause**: VARIANT 경로 접근 시 타입 캐스팅 누락
+
+**Solution**:
+```sql
+-- ❌ Bad: 타입 캐스팅 없이 비교
+SELECT * FROM LEARNING_LOGS WHERE ACTIVITY_DATA:score > 80;
+
+-- ✅ Good: 명시적 타입 캐스팅
+SELECT * FROM LEARNING_LOGS WHERE ACTIVITY_DATA:score::NUMBER > 80;
+```
+
+### Issue 2: Warehouse 크기 부적절
+
+**Symptom**: 쿼리가 느리거나 크레딧 낭비
+
+**Solution**:
+```sql
+-- 쿼리 프로파일 확인
+SELECT QUERY_ID, WAREHOUSE_SIZE, EXECUTION_TIME, BYTES_SCANNED
+FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY())
+WHERE EXECUTION_TIME > 60000  -- 60초 이상
+ORDER BY EXECUTION_TIME DESC;
+
+-- Warehouse 크기 조정
+ALTER WAREHOUSE TRANSFORM_WH SET WAREHOUSE_SIZE = 'MEDIUM';
+```
+
+### Issue 3: Time Travel 스토리지 비용
+
+**Symptom**: 스토리지 비용 급증
+
+**Solution**:
+```sql
+-- 테이블별 스토리지 확인
+SELECT TABLE_NAME, ACTIVE_BYTES, TIME_TRAVEL_BYTES, FAILSAFE_BYTES
+FROM INFORMATION_SCHEMA.TABLE_STORAGE_METRICS
+ORDER BY TIME_TRAVEL_BYTES DESC;
+
+-- 임시 테이블은 Transient로 전환
+CREATE TRANSIENT TABLE EDU_ANALYTICS.STAGING.TEMP_DATA (...);
+```
+
+## References
+
+### Official Documentation
+- [Snowflake SQL Reference](https://docs.snowflake.com/en/sql-reference)
+- [Snowflake Data Types](https://docs.snowflake.com/en/sql-reference/data-types)
+- [Clustering Keys](https://docs.snowflake.com/en/user-guide/tables-clustering-keys)
+- [Streams and Tasks](https://docs.snowflake.com/en/user-guide/streams)
+- [Dynamic Tables](https://docs.snowflake.com/en/user-guide/dynamic-tables-about)
+
+## Metadata
+
+### Version
+- **Current Version**: 1.0.0
+- **Last Updated**: 2026-04-07
+- **Target Platform**: Snowflake
+
+### Tags
+`#database` `#schema` `#Snowflake` `#SQL` `#VARIANT` `#clustering` `#data-loading` `#Time-Travel` `#Streams` `#Tasks`

--- a/.claude/skills/git-commit/.ai.md
+++ b/.claude/skills/git-commit/.ai.md
@@ -1,0 +1,15 @@
+# git-commit 스킬
+
+## 목적
+Conventional Commits 규격에 따라 git 커밋 메시지를 자동 분석·생성하는 스킬.
+
+## 파일 구조
+- `SKILL.md` — 스킬 본문 (커밋 타입, 워크플로우, 안전 프로토콜)
+
+## 역할
+- staged/unstaged diff 분석하여 적절한 type/scope 결정
+- Conventional Commit 형식의 메시지 생성
+- Git 안전 프로토콜 준수 (force push 금지, hook skip 금지 등)
+
+## 트리거 키워드
+`commit`, `커밋`, `conventional commit`

--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: git-commit
+description: 'Execute git commit with conventional commit message analysis, intelligent staging, and message generation. Use when user asks to commit changes, create a git commit, or mentions "/commit". Supports: (1) Auto-detecting type and scope from changes, (2) Generating conventional commit messages from diff, (3) Interactive commit with optional type/scope/description overrides, (4) Intelligent file staging for logical grouping'
+license: MIT
+allowed-tools: Bash
+---
+
+# Git Commit with Conventional Commits
+
+## Overview
+
+Create standardized, semantic git commits using the Conventional Commits specification. Analyze the actual diff to determine appropriate type, scope, and message.
+
+## Conventional Commit Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## Commit Types
+
+| Type       | Purpose                        |
+| ---------- | ------------------------------ |
+| `feat`     | New feature                    |
+| `fix`      | Bug fix                        |
+| `docs`     | Documentation only             |
+| `style`    | Formatting/style (no logic)    |
+| `refactor` | Code refactor (no feature/fix) |
+| `perf`     | Performance improvement        |
+| `test`     | Add/update tests               |
+| `build`    | Build system/dependencies      |
+| `ci`       | CI/config changes              |
+| `chore`    | Maintenance/misc               |
+| `revert`   | Revert commit                  |
+
+## Breaking Changes
+
+```
+# Exclamation mark after type/scope
+feat!: remove deprecated endpoint
+
+# BREAKING CHANGE footer
+feat: allow config to extend other configs
+
+BREAKING CHANGE: `extends` key behavior changed
+```
+
+## Workflow
+
+### 1. Analyze Diff
+
+```bash
+# If files are staged, use staged diff
+git diff --staged
+
+# If nothing staged, use working tree diff
+git diff
+
+# Also check status
+git status --porcelain
+```
+
+### 2. Stage Files (if needed)
+
+If nothing is staged or you want to group changes differently:
+
+```bash
+# Stage specific files
+git add path/to/file1 path/to/file2
+
+# Stage by pattern
+git add *.test.*
+git add src/components/*
+
+# Interactive staging
+git add -p
+```
+
+**Never commit secrets** (.env, credentials.json, private keys).
+
+### 3. Generate Commit Message
+
+Analyze the diff to determine:
+
+- **Type**: What kind of change is this?
+- **Scope**: What area/module is affected?
+- **Description**: One-line summary of what changed (present tense, imperative mood, <72 chars)
+
+### 4. Execute Commit
+
+```bash
+# Single line
+git commit -m "<type>[scope]: <description>"
+
+# Multi-line with body/footer
+git commit -m "$(cat <<'EOF'
+<type>[scope]: <description>
+
+<optional body>
+
+<optional footer>
+EOF
+)"
+```
+
+## Best Practices
+
+- One logical change per commit
+- Present tense: "add" not "added"
+- Imperative mood: "fix bug" not "fixes bug"
+- Reference issues: `Closes #123`, `Refs #456`
+- Keep description under 72 characters
+
+## Git Safety Protocol
+
+- NEVER update git config
+- NEVER run destructive commands (--force, hard reset) without explicit request
+- NEVER skip hooks (--no-verify) unless user asks
+- NEVER force push to main/master
+- If commit fails due to hooks, fix and create NEW commit (don't amend)

--- a/.claude/skills/security-best-practices/.ai.md
+++ b/.claude/skills/security-best-practices/.ai.md
@@ -1,0 +1,18 @@
+# security-best-practices 스킬
+
+## 목적
+Snowflake 환경의 보안 설정을 설계하고 강화하는 도메인 스킬.
+
+## 파일 구조
+- `SKILL.md` — 스킬 본문 (Snowflake 전용 보안 가이드)
+
+## 역할
+- RBAC 역할 계층 설계 (ACCOUNTADMIN/SECURITYADMIN/SYSADMIN 분리)
+- Network Policy 구성 (IP 화이트리스트)
+- Dynamic Data Masking (민감 데이터 마스킹 정책)
+- Row Access Policy (행 수준 보안)
+- MFA, 비밀번호 정책, 세션 정책
+- 감사 및 모니터링 (LOGIN_HISTORY, ACCESS_HISTORY)
+
+## 트리거 키워드
+`보안`, `security`, `rbac`, `masking`, `network policy`, `row access`, `권한`, `role`, `grant`, `감사`, `audit`

--- a/.claude/skills/security-best-practices/SKILL.md
+++ b/.claude/skills/security-best-practices/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: security-best-practices
+description: Implement Snowflake security best practices. Use when configuring access control, RBAC, network policies, data masking, row access policies, or auditing. Handles Snowflake RBAC hierarchy, encryption, MFA, session policies, and compliance requirements.
+metadata:
+  tags: security, Snowflake, RBAC, masking-policy, network-policy, row-access-policy, audit
+  platforms: Claude
+---
+
+
+# Snowflake Security Best Practices
+
+
+## When to use this skill
+
+- **New project**: Snowflake 환경 초기 보안 구성
+- **Access control**: RBAC 역할 계층 설계 및 권한 관리
+- **Data protection**: 민감 데이터 마스킹, 행 수준 보안
+- **Network security**: IP 제한, 프라이빗 연결 구성
+- **Compliance**: GDPR, HIPAA, PCI-DSS 등 컴플라이언스 요구사항 충족
+- **Security audit**: 기존 보안 설정 점검 및 강화
+
+## Instructions
+
+### Step 1: RBAC 역할 계층 설계
+
+Snowflake의 역할 기반 접근 제어(RBAC)를 설계한다.
+
+**핵심 원칙**:
+- 최소 권한 원칙 (Principle of Least Privilege)
+- 시스템 역할 분리: `ACCOUNTADMIN`, `SECURITYADMIN`, `SYSADMIN`, `USERADMIN`
+- 커스텀 역할은 `SYSADMIN`에 GRANT하여 계층 유지
+
+**Tasks**:
+- 기능별 커스텀 역할 생성
+- 역할 계층 구조 설계
+- 사용자-역할 매핑
+
+**Example**:
+```sql
+-- 커스텀 역할 생성
+CREATE ROLE EDU_ADMIN;        -- 교육 데이터 관리자
+CREATE ROLE EDU_ANALYST;      -- 분석가 (읽기 전용)
+CREATE ROLE EDU_DATA_ENGINEER; -- 데이터 엔지니어 (ETL)
+CREATE ROLE EDU_APP_SERVICE;  -- 애플리케이션 서비스 계정
+
+-- 역할 계층 구성 (상위 역할이 하위 역할 권한 상속)
+GRANT ROLE EDU_ANALYST TO ROLE EDU_DATA_ENGINEER;
+GRANT ROLE EDU_DATA_ENGINEER TO ROLE EDU_ADMIN;
+GRANT ROLE EDU_ADMIN TO ROLE SYSADMIN;  -- SYSADMIN 계층에 연결 필수
+
+-- 역할별 권한 부여
+-- Analyst: 분석 스키마 읽기 전용
+GRANT USAGE ON DATABASE EDU_ANALYTICS TO ROLE EDU_ANALYST;
+GRANT USAGE ON SCHEMA EDU_ANALYTICS.ANALYTICS TO ROLE EDU_ANALYST;
+GRANT SELECT ON ALL TABLES IN SCHEMA EDU_ANALYTICS.ANALYTICS TO ROLE EDU_ANALYST;
+GRANT SELECT ON FUTURE TABLES IN SCHEMA EDU_ANALYTICS.ANALYTICS TO ROLE EDU_ANALYST;
+
+-- Data Engineer: RAW/STAGING 스키마 쓰기
+GRANT USAGE ON SCHEMA EDU_ANALYTICS.RAW TO ROLE EDU_DATA_ENGINEER;
+GRANT USAGE ON SCHEMA EDU_ANALYTICS.STAGING TO ROLE EDU_DATA_ENGINEER;
+GRANT CREATE TABLE ON SCHEMA EDU_ANALYTICS.RAW TO ROLE EDU_DATA_ENGINEER;
+GRANT CREATE TABLE ON SCHEMA EDU_ANALYTICS.STAGING TO ROLE EDU_DATA_ENGINEER;
+GRANT INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA EDU_ANALYTICS.RAW TO ROLE EDU_DATA_ENGINEER;
+
+-- App Service: 특정 테이블만 읽기
+GRANT SELECT ON TABLE EDU_ANALYTICS.ANALYTICS.STUDENTS TO ROLE EDU_APP_SERVICE;
+GRANT SELECT ON TABLE EDU_ANALYTICS.ANALYTICS.COURSES TO ROLE EDU_APP_SERVICE;
+GRANT SELECT ON TABLE EDU_ANALYTICS.ANALYTICS.ENROLLMENTS TO ROLE EDU_APP_SERVICE;
+
+-- Warehouse 접근 제어
+GRANT USAGE ON WAREHOUSE ANALYTICS_WH TO ROLE EDU_ANALYST;
+GRANT USAGE ON WAREHOUSE TRANSFORM_WH TO ROLE EDU_DATA_ENGINEER;
+GRANT USAGE ON WAREHOUSE APP_WH TO ROLE EDU_APP_SERVICE;
+
+-- 사용자에 역할 부여
+GRANT ROLE EDU_ANALYST TO USER analyst_user;
+GRANT ROLE EDU_DATA_ENGINEER TO USER etl_user;
+```
+
+**역할 계층 다이어그램**:
+```
+ACCOUNTADMIN
+├── SECURITYADMIN (역할/사용자 관리)
+├── USERADMIN (사용자 생성)
+└── SYSADMIN (오브젝트 관리)
+    └── EDU_ADMIN
+        └── EDU_DATA_ENGINEER
+            └── EDU_ANALYST
+    └── EDU_APP_SERVICE
+```
+
+### Step 2: Network Policies 구성
+
+IP 기반 접근 제한으로 네트워크 수준 보안을 강화한다.
+
+**Example**:
+```sql
+-- Network Policy 생성: 허용 IP만 접근
+CREATE NETWORK POLICY EDU_NETWORK_POLICY
+    ALLOWED_IP_LIST = (
+        '10.0.0.0/8',           -- 내부 네트워크
+        '203.0.113.0/24',       -- 오피스 IP 대역
+        '198.51.100.50/32'      -- VPN Gateway
+    )
+    BLOCKED_IP_LIST = (
+        '203.0.113.99/32'       -- 차단할 특정 IP
+    );
+
+-- 계정 전체에 Network Policy 적용
+ALTER ACCOUNT SET NETWORK_POLICY = EDU_NETWORK_POLICY;
+
+-- 특정 사용자에게만 별도 Policy 적용
+CREATE NETWORK POLICY SERVICE_ACCOUNT_POLICY
+    ALLOWED_IP_LIST = ('10.0.1.0/24');
+
+ALTER USER etl_service SET NETWORK_POLICY = SERVICE_ACCOUNT_POLICY;
+
+-- Network Policy 확인
+DESCRIBE NETWORK POLICY EDU_NETWORK_POLICY;
+```
+
+### Step 3: Dynamic Data Masking
+
+민감 데이터를 역할 기반으로 동적 마스킹한다.
+
+**Example**:
+```sql
+-- 이메일 마스킹 정책
+CREATE MASKING POLICY EDU_ANALYTICS.COMMON.EMAIL_MASK AS
+    (VAL VARCHAR) RETURNS VARCHAR ->
+    CASE
+        WHEN CURRENT_ROLE() IN ('EDU_ADMIN', 'ACCOUNTADMIN')
+            THEN VAL
+        WHEN CURRENT_ROLE() = 'EDU_DATA_ENGINEER'
+            THEN REGEXP_REPLACE(VAL, '(.{2})(.*)(@.*)', '\\1***\\3')
+        ELSE '***@***.***'
+    END;
+
+-- 이름 부분 마스킹 정책
+CREATE MASKING POLICY EDU_ANALYTICS.COMMON.NAME_MASK AS
+    (VAL VARCHAR) RETURNS VARCHAR ->
+    CASE
+        WHEN CURRENT_ROLE() IN ('EDU_ADMIN', 'ACCOUNTADMIN')
+            THEN VAL
+        ELSE CONCAT(LEFT(VAL, 1), '***')
+    END;
+
+-- VARIANT 내부 필드 마스킹 (JSON 프로필의 phone 필드)
+CREATE MASKING POLICY EDU_ANALYTICS.COMMON.VARIANT_PII_MASK AS
+    (VAL VARIANT) RETURNS VARIANT ->
+    CASE
+        WHEN CURRENT_ROLE() IN ('EDU_ADMIN', 'ACCOUNTADMIN')
+            THEN VAL
+        ELSE OBJECT_DELETE(VAL, 'phone', 'address', 'ssn')
+    END;
+
+-- 테이블에 마스킹 정책 적용
+ALTER TABLE EDU_ANALYTICS.ANALYTICS.STUDENTS
+    MODIFY COLUMN EMAIL SET MASKING POLICY EDU_ANALYTICS.COMMON.EMAIL_MASK;
+
+ALTER TABLE EDU_ANALYTICS.ANALYTICS.STUDENTS
+    MODIFY COLUMN NAME SET MASKING POLICY EDU_ANALYTICS.COMMON.NAME_MASK;
+
+ALTER TABLE EDU_ANALYTICS.ANALYTICS.STUDENTS
+    MODIFY COLUMN PROFILE SET MASKING POLICY EDU_ANALYTICS.COMMON.VARIANT_PII_MASK;
+```
+
+### Step 4: Row Access Policies
+
+행 수준 보안으로 데이터 접근 범위를 제한한다.
+
+**Example**:
+```sql
+-- 학과별 데이터 접근 제한
+-- 매핑 테이블: 역할-학과 매핑
+CREATE TABLE EDU_ANALYTICS.COMMON.ROLE_DEPARTMENT_MAPPING (
+    ROLE_NAME VARCHAR(100),
+    DEPARTMENT_ID NUMBER
+);
+
+INSERT INTO EDU_ANALYTICS.COMMON.ROLE_DEPARTMENT_MAPPING VALUES
+    ('CS_DEPT_ANALYST', 1),
+    ('MATH_DEPT_ANALYST', 2),
+    ('EDU_ADMIN', NULL);  -- NULL = 전체 접근
+
+-- Row Access Policy 생성
+CREATE ROW ACCESS POLICY EDU_ANALYTICS.COMMON.DEPARTMENT_ACCESS AS
+    (DEPT_ID NUMBER) RETURNS BOOLEAN ->
+    CURRENT_ROLE() IN ('EDU_ADMIN', 'ACCOUNTADMIN')
+    OR EXISTS (
+        SELECT 1 FROM EDU_ANALYTICS.COMMON.ROLE_DEPARTMENT_MAPPING
+        WHERE ROLE_NAME = CURRENT_ROLE()
+        AND (DEPARTMENT_ID = DEPT_ID OR DEPARTMENT_ID IS NULL)
+    );
+
+-- 테이블에 적용
+ALTER TABLE EDU_ANALYTICS.ANALYTICS.STUDENTS
+    ADD ROW ACCESS POLICY EDU_ANALYTICS.COMMON.DEPARTMENT_ACCESS
+    ON (DEPARTMENT_ID);
+```
+
+### Step 5: MFA 및 사용자 보안
+
+다중 인증과 사용자 보안 설정을 강화한다.
+
+**Example**:
+```sql
+-- MFA 필수화 (관리자 계정)
+ALTER USER admin_user SET MINS_TO_BYPASS_MFA = 0;
+
+-- 비밀번호 정책 생성
+CREATE PASSWORD POLICY EDU_PASSWORD_POLICY
+    PASSWORD_MIN_LENGTH = 14
+    PASSWORD_MAX_LENGTH = 256
+    PASSWORD_MIN_UPPER_CASE_CHARS = 1
+    PASSWORD_MIN_LOWER_CASE_CHARS = 1
+    PASSWORD_MIN_NUMERIC_CHARS = 1
+    PASSWORD_MIN_SPECIAL_CHARS = 1
+    PASSWORD_MAX_AGE_DAYS = 90
+    PASSWORD_MAX_RETRIES = 5
+    PASSWORD_LOCKOUT_TIME_MINS = 30
+    PASSWORD_HISTORY = 12;
+
+-- 계정에 비밀번호 정책 적용
+ALTER ACCOUNT SET PASSWORD POLICY = EDU_PASSWORD_POLICY;
+
+-- 세션 정책 설정
+CREATE SESSION POLICY EDU_SESSION_POLICY
+    SESSION_IDLE_TIMEOUT_MINS = 30
+    SESSION_UI_IDLE_TIMEOUT_MINS = 15;
+
+ALTER ACCOUNT SET SESSION POLICY = EDU_SESSION_POLICY;
+
+-- 서비스 계정: Key Pair 인증 (비밀번호 대신)
+-- RSA 키 생성 후:
+ALTER USER etl_service SET RSA_PUBLIC_KEY = 'MIIBIjANBg...';
+ALTER USER etl_service SET PASSWORD = NULL;  -- 비밀번호 비활성화
+```
+
+### Step 6: 감사 및 모니터링
+
+보안 이벤트를 추적하고 모니터링한다.
+
+**Example**:
+```sql
+-- 로그인 이력 조회
+SELECT USER_NAME, CLIENT_IP, REPORTED_CLIENT_TYPE,
+       FIRST_AUTHENTICATION_FACTOR, IS_SUCCESS,
+       ERROR_CODE, ERROR_MESSAGE
+FROM SNOWFLAKE.ACCOUNT_USAGE.LOGIN_HISTORY
+WHERE EVENT_TIMESTAMP > DATEADD(DAY, -7, CURRENT_TIMESTAMP())
+AND IS_SUCCESS = 'NO'
+ORDER BY EVENT_TIMESTAMP DESC;
+
+-- 접근 이력 조회 (누가 어떤 데이터에 접근했는지)
+SELECT USER_NAME, QUERY_ID,
+       DIRECT_OBJECTS_ACCESSED,
+       BASE_OBJECTS_ACCESSED,
+       OBJECTS_MODIFIED
+FROM SNOWFLAKE.ACCOUNT_USAGE.ACCESS_HISTORY
+WHERE QUERY_START_TIME > DATEADD(DAY, -1, CURRENT_TIMESTAMP())
+ORDER BY QUERY_START_TIME DESC;
+
+-- 권한 변경 이력
+SELECT QUERY_TEXT, USER_NAME, ROLE_NAME, EXECUTION_STATUS
+FROM SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY
+WHERE QUERY_TYPE IN ('GRANT', 'REVOKE')
+AND START_TIME > DATEADD(DAY, -30, CURRENT_TIMESTAMP())
+ORDER BY START_TIME DESC;
+
+-- 비정상 접근 탐지: 업무 시간 외 접근
+SELECT USER_NAME, COUNT(*) AS OFF_HOURS_QUERIES,
+       MIN(START_TIME) AS FIRST_QUERY, MAX(START_TIME) AS LAST_QUERY
+FROM SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY
+WHERE HOUR(START_TIME) NOT BETWEEN 8 AND 20  -- 업무 시간 외
+AND START_TIME > DATEADD(DAY, -7, CURRENT_TIMESTAMP())
+GROUP BY USER_NAME
+HAVING COUNT(*) > 10
+ORDER BY OFF_HOURS_QUERIES DESC;
+
+-- Resource Monitor로 비용 이상 탐지
+CREATE RESOURCE MONITOR EDU_MONITOR
+    WITH CREDIT_QUOTA = 100
+    FREQUENCY = MONTHLY
+    START_TIMESTAMP = IMMEDIATELY
+    TRIGGERS
+        ON 80 PERCENT DO NOTIFY
+        ON 95 PERCENT DO SUSPEND
+        ON 100 PERCENT DO SUSPEND_IMMEDIATE;
+
+ALTER WAREHOUSE ANALYTICS_WH SET RESOURCE_MONITOR = EDU_MONITOR;
+```
+
+## Constraints
+
+### Required Rules (MUST)
+
+1. **RBAC 필수**: 모든 사용자에게 커스텀 역할 부여, `ACCOUNTADMIN` 직접 사용 금지
+2. **Network Policy 적용**: 프로덕션 환경에 IP 제한 필수
+3. **MFA 활성화**: 관리자 계정(`ACCOUNTADMIN`, `SECURITYADMIN`) MFA 필수
+4. **민감 데이터 마스킹**: PII 컬럼에 Masking Policy 적용
+5. **감사 로그 모니터링**: `LOGIN_HISTORY`, `ACCESS_HISTORY` 정기 점검
+
+### Prohibited Items (MUST NOT)
+
+1. **ACCOUNTADMIN으로 일상 작업 금지**: 관리 작업에만 사용
+2. **GRANT ALL PRIVILEGES 금지**: 필요한 권한만 개별 부여
+3. **공유 계정 금지**: 사용자별 개별 계정 생성, 서비스 계정은 Key Pair 인증
+4. **비밀번호 하드코딩 금지**: 연결 문자열에 비밀번호 포함하지 않음
+5. **PUBLIC 역할에 권한 부여 금지**: 모든 사용자에게 노출됨
+
+## Security Checklist
+
+```markdown
+- [ ] RBAC: 커스텀 역할 계층이 SYSADMIN에 연결됨
+- [ ] RBAC: 최소 권한 원칙 적용 (GRANT 범위 확인)
+- [ ] Network: Network Policy가 계정에 적용됨
+- [ ] Network: 허용 IP 목록이 최소화됨
+- [ ] Auth: ACCOUNTADMIN/SECURITYADMIN에 MFA 활성화
+- [ ] Auth: 서비스 계정은 Key Pair 인증 사용
+- [ ] Auth: 비밀번호 정책 적용 (최소 14자, 복잡성 요구)
+- [ ] Auth: 세션 타임아웃 설정
+- [ ] Data: PII 컬럼에 Masking Policy 적용
+- [ ] Data: 필요 시 Row Access Policy 적용
+- [ ] Data: Time Travel 보존 기간 적절히 설정
+- [ ] Audit: LOGIN_HISTORY 실패 로그인 모니터링
+- [ ] Audit: ACCESS_HISTORY 정기 점검
+- [ ] Audit: Resource Monitor 설정 (비용 이상 탐지)
+- [ ] Encryption: 기본 AES-256 암호화 확인 (Snowflake 기본 제공)
+- [ ] Encryption: 필요 시 Tri-Secret Secure (고객 관리 키) 구성
+```
+
+## Best Practices
+
+1. **Principle of Least Privilege**: 필요한 최소 권한만 부여
+2. **Defense in Depth**: Network Policy + RBAC + Masking + Row Access 다층 방어
+3. **Regular Audits**: 월 1회 이상 권한 검토 및 불필요 권한 회수
+4. **Separation of Duties**: 관리 역할(`SECURITYADMIN`)과 운영 역할(`SYSADMIN`) 분리
+5. **Automate Security**: Terraform/Snowflake CLI로 보안 설정 IaC 관리
+
+## References
+
+- [Snowflake Access Control](https://docs.snowflake.com/en/user-guide/security-access-control)
+- [Network Policies](https://docs.snowflake.com/en/user-guide/network-policies)
+- [Dynamic Data Masking](https://docs.snowflake.com/en/user-guide/security-column-ddm-use)
+- [Row Access Policies](https://docs.snowflake.com/en/user-guide/security-row-intro)
+- [Snowflake Security Overview](https://docs.snowflake.com/en/user-guide/admin-security)
+- [Account Usage Views](https://docs.snowflake.com/en/sql-reference/account-usage)
+
+## Metadata
+
+### Version
+- **Current Version**: 1.0.0
+- **Last Updated**: 2026-04-07
+- **Target Platform**: Snowflake
+
+### Tags
+`#security` `#Snowflake` `#RBAC` `#masking-policy` `#network-policy` `#row-access-policy` `#audit` `#MFA` `#encryption`

--- a/.claude/skills/skill-rules.json
+++ b/.claude/skills/skill-rules.json
@@ -1,0 +1,109 @@
+{
+    "version": "1.0",
+    "description": "Skill activation triggers for Claude Code. Controls when skills automatically suggest or block actions.",
+    "skills": {
+        "database-schema-design": {
+            "type": "domain",
+            "enforcement": "suggest",
+            "priority": "high",
+            "description": "Snowflake 데이터베이스 스키마 설계 (VARIANT, CLUSTER BY, Time Travel, Streams/Tasks)",
+            "promptTriggers": {
+                "keywords": [
+                    "스키마",
+                    "schema",
+                    "테이블 설계",
+                    "snowflake",
+                    "variant",
+                    "cluster by",
+                    "copy into",
+                    "stage",
+                    "time travel",
+                    "데이터 모델링",
+                    "ERD",
+                    "dynamic table",
+                    "스트림",
+                    "stream"
+                ],
+                "intentPatterns": [
+                    "(설계|design|create).*?(schema|테이블|table|database)",
+                    "(snowflake|스노우플레이크).*?(schema|table|설계)",
+                    "(데이터|data).*?(모델|model|구조|structure)"
+                ]
+            }
+        },
+        "git-commit": {
+            "type": "domain",
+            "enforcement": "suggest",
+            "priority": "medium",
+            "description": "Conventional Commits 자동 분석 및 커밋 메시지 생성",
+            "promptTriggers": {
+                "keywords": [
+                    "commit",
+                    "커밋",
+                    "conventional commit"
+                ],
+                "intentPatterns": [
+                    "(git|깃).*?commit",
+                    "커밋.*?(메시지|message)"
+                ]
+            }
+        },
+        "test-driven-development": {
+            "type": "guardrail",
+            "enforcement": "warn",
+            "priority": "high",
+            "description": "TDD Red-Green-Refactor 사이클 강제",
+            "promptTriggers": {
+                "keywords": [
+                    "tdd",
+                    "test first",
+                    "테스트 먼저",
+                    "red green refactor"
+                ],
+                "intentPatterns": [
+                    "(구현|implement|build|만들).*?(feature|기능|버그|bug|fix)"
+                ]
+            }
+        },
+        "security-best-practices": {
+            "type": "domain",
+            "enforcement": "suggest",
+            "priority": "high",
+            "description": "Snowflake 보안 설정 (RBAC, Network Policy, Data Masking, Row Access Policy)",
+            "promptTriggers": {
+                "keywords": [
+                    "보안",
+                    "security",
+                    "rbac",
+                    "masking",
+                    "network policy",
+                    "row access",
+                    "권한",
+                    "role",
+                    "grant",
+                    "마스킹",
+                    "감사",
+                    "audit"
+                ],
+                "intentPatterns": [
+                    "(보안|security|secure).*?(설정|config|review|검토)",
+                    "(권한|role|grant|revoke).*?(설정|설계|design)",
+                    "(masking|마스킹).*?(policy|정책)"
+                ]
+            }
+        }
+    },
+    "notes": {
+        "enforcement_types": {
+            "suggest": "Skill suggestion appears but doesn't block execution",
+            "block": "Requires skill to be used before proceeding (guardrail)",
+            "warn": "Shows warning but allows proceeding"
+        },
+        "priority_levels": {
+            "critical": "Highest - Always trigger when matched",
+            "high": "Important - Trigger for most matches",
+            "medium": "Moderate - Trigger for clear matches",
+            "low": "Optional - Trigger only for explicit matches"
+        }
+    }
+}

--- a/.claude/skills/test-driven-development/.ai.md
+++ b/.claude/skills/test-driven-development/.ai.md
@@ -1,0 +1,16 @@
+# test-driven-development 스킬
+
+## 목적
+TDD(Test-Driven Development) Red-Green-Refactor 사이클을 강제하는 guardrail 스킬.
+
+## 파일 구조
+- `SKILL.md` — 스킬 본문 (TDD 원칙, 사이클, 검증 체크리스트)
+- `testing-anti-patterns.md` — 테스팅 안티패턴 참조 문서 (Mock 남용, 테스트 전용 메서드 등)
+
+## 역할
+- 구현 전 테스트 작성 강제 ("NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST")
+- 합리화 패턴 차단 (코드 먼저, 나중에 테스트 등)
+- 안티패턴 감지 및 경고
+
+## 트리거 키워드
+`tdd`, `test first`, `테스트 먼저`, `red green refactor`

--- a/.claude/skills/test-driven-development/SKILL.md
+++ b/.claude/skills/test-driven-development/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: test-driven-development
+description: Use when implementing any feature or bugfix, before writing implementation code
+---
+
+# Test-Driven Development (TDD)
+
+## Overview
+
+Write the test first. Watch it fail. Write minimal code to pass.
+
+**Core principle:** If you didn't watch the test fail, you don't know if it tests the right thing.
+
+**Violating the letter of the rules is violating the spirit of the rules.**
+
+## When to Use
+
+**Always:**
+- New features
+- Bug fixes
+- Refactoring
+- Behavior changes
+
+**Exceptions (ask your human partner):**
+- Throwaway prototypes
+- Generated code
+- Configuration files
+
+Thinking "skip TDD just this once"? Stop. That's rationalization.
+
+## The Iron Law
+
+```
+NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
+```
+
+Write code before the test? Delete it. Start over.
+
+**No exceptions:**
+- Don't keep it as "reference"
+- Don't "adapt" it while writing tests
+- Don't look at it
+- Delete means delete
+
+Implement fresh from tests. Period.
+
+## Red-Green-Refactor
+
+```dot
+digraph tdd_cycle {
+    rankdir=LR;
+    red [label="RED\nWrite failing test", shape=box, style=filled, fillcolor="#ffcccc"];
+    verify_red [label="Verify fails\ncorrectly", shape=diamond];
+    green [label="GREEN\nMinimal code", shape=box, style=filled, fillcolor="#ccffcc"];
+    verify_green [label="Verify passes\nAll green", shape=diamond];
+    refactor [label="REFACTOR\nClean up", shape=box, style=filled, fillcolor="#ccccff"];
+    next [label="Next", shape=ellipse];
+
+    red -> verify_red;
+    verify_red -> green [label="yes"];
+    verify_red -> red [label="wrong\nfailure"];
+    green -> verify_green;
+    verify_green -> refactor [label="yes"];
+    verify_green -> green [label="no"];
+    refactor -> verify_green [label="stay\ngreen"];
+    verify_green -> next;
+    next -> red;
+}
+```
+
+### RED - Write Failing Test
+
+Write one minimal test showing what should happen.
+
+<Good>
+```typescript
+test('retries failed operations 3 times', async () => {
+  let attempts = 0;
+  const operation = () => {
+    attempts++;
+    if (attempts < 3) throw new Error('fail');
+    return 'success';
+  };
+
+  const result = await retryOperation(operation);
+
+  expect(result).toBe('success');
+  expect(attempts).toBe(3);
+});
+```
+Clear name, tests real behavior, one thing
+</Good>
+
+<Bad>
+```typescript
+test('retry works', async () => {
+  const mock = jest.fn()
+    .mockRejectedValueOnce(new Error())
+    .mockRejectedValueOnce(new Error())
+    .mockResolvedValueOnce('success');
+  await retryOperation(mock);
+  expect(mock).toHaveBeenCalledTimes(3);
+});
+```
+Vague name, tests mock not code
+</Bad>
+
+**Requirements:**
+- One behavior
+- Clear name
+- Real code (no mocks unless unavoidable)
+
+### Verify RED - Watch It Fail
+
+**MANDATORY. Never skip.**
+
+```bash
+npm test path/to/test.test.ts
+```
+
+Confirm:
+- Test fails (not errors)
+- Failure message is expected
+- Fails because feature missing (not typos)
+
+**Test passes?** You're testing existing behavior. Fix test.
+
+**Test errors?** Fix error, re-run until it fails correctly.
+
+### GREEN - Minimal Code
+
+Write simplest code to pass the test.
+
+<Good>
+```typescript
+async function retryOperation<T>(fn: () => Promise<T>): Promise<T> {
+  for (let i = 0; i < 3; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (i === 2) throw e;
+    }
+  }
+  throw new Error('unreachable');
+}
+```
+Just enough to pass
+</Good>
+
+<Bad>
+```typescript
+async function retryOperation<T>(
+  fn: () => Promise<T>,
+  options?: {
+    maxRetries?: number;
+    backoff?: 'linear' | 'exponential';
+    onRetry?: (attempt: number) => void;
+  }
+): Promise<T> {
+  // YAGNI
+}
+```
+Over-engineered
+</Bad>
+
+Don't add features, refactor other code, or "improve" beyond the test.
+
+### Verify GREEN - Watch It Pass
+
+**MANDATORY.**
+
+```bash
+npm test path/to/test.test.ts
+```
+
+Confirm:
+- Test passes
+- Other tests still pass
+- Output pristine (no errors, warnings)
+
+**Test fails?** Fix code, not test.
+
+**Other tests fail?** Fix now.
+
+### REFACTOR - Clean Up
+
+After green only:
+- Remove duplication
+- Improve names
+- Extract helpers
+
+Keep tests green. Don't add behavior.
+
+### Repeat
+
+Next failing test for next feature.
+
+## Good Tests
+
+| Quality | Good | Bad |
+|---------|------|-----|
+| **Minimal** | One thing. "and" in name? Split it. | `test('validates email and domain and whitespace')` |
+| **Clear** | Name describes behavior | `test('test1')` |
+| **Shows intent** | Demonstrates desired API | Obscures what code should do |
+
+## Why Order Matters
+
+**"I'll write tests after to verify it works"**
+
+Tests written after code pass immediately. Passing immediately proves nothing:
+- Might test wrong thing
+- Might test implementation, not behavior
+- Might miss edge cases you forgot
+- You never saw it catch the bug
+
+Test-first forces you to see the test fail, proving it actually tests something.
+
+**"I already manually tested all the edge cases"**
+
+Manual testing is ad-hoc. You think you tested everything but:
+- No record of what you tested
+- Can't re-run when code changes
+- Easy to forget cases under pressure
+- "It worked when I tried it" ≠ comprehensive
+
+Automated tests are systematic. They run the same way every time.
+
+**"Deleting X hours of work is wasteful"**
+
+Sunk cost fallacy. The time is already gone. Your choice now:
+- Delete and rewrite with TDD (X more hours, high confidence)
+- Keep it and add tests after (30 min, low confidence, likely bugs)
+
+The "waste" is keeping code you can't trust. Working code without real tests is technical debt.
+
+**"TDD is dogmatic, being pragmatic means adapting"**
+
+TDD IS pragmatic:
+- Finds bugs before commit (faster than debugging after)
+- Prevents regressions (tests catch breaks immediately)
+- Documents behavior (tests show how to use code)
+- Enables refactoring (change freely, tests catch breaks)
+
+"Pragmatic" shortcuts = debugging in production = slower.
+
+**"Tests after achieve the same goals - it's spirit not ritual"**
+
+No. Tests-after answer "What does this do?" Tests-first answer "What should this do?"
+
+Tests-after are biased by your implementation. You test what you built, not what's required. You verify remembered edge cases, not discovered ones.
+
+Tests-first force edge case discovery before implementing. Tests-after verify you remembered everything (you didn't).
+
+30 minutes of tests after ≠ TDD. You get coverage, lose proof tests work.
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "Too simple to test" | Simple code breaks. Test takes 30 seconds. |
+| "I'll test after" | Tests passing immediately prove nothing. |
+| "Tests after achieve same goals" | Tests-after = "what does this do?" Tests-first = "what should this do?" |
+| "Already manually tested" | Ad-hoc ≠ systematic. No record, can't re-run. |
+| "Deleting X hours is wasteful" | Sunk cost fallacy. Keeping unverified code is technical debt. |
+| "Keep as reference, write tests first" | You'll adapt it. That's testing after. Delete means delete. |
+| "Need to explore first" | Fine. Throw away exploration, start with TDD. |
+| "Test hard = design unclear" | Listen to test. Hard to test = hard to use. |
+| "TDD will slow me down" | TDD faster than debugging. Pragmatic = test-first. |
+| "Manual test faster" | Manual doesn't prove edge cases. You'll re-test every change. |
+| "Existing code has no tests" | You're improving it. Add tests for existing code. |
+
+## Red Flags - STOP and Start Over
+
+- Code before test
+- Test after implementation
+- Test passes immediately
+- Can't explain why test failed
+- Tests added "later"
+- Rationalizing "just this once"
+- "I already manually tested it"
+- "Tests after achieve the same purpose"
+- "It's about spirit not ritual"
+- "Keep as reference" or "adapt existing code"
+- "Already spent X hours, deleting is wasteful"
+- "TDD is dogmatic, I'm being pragmatic"
+- "This is different because..."
+
+**All of these mean: Delete code. Start over with TDD.**
+
+## Example: Bug Fix
+
+**Bug:** Empty email accepted
+
+**RED**
+```typescript
+test('rejects empty email', async () => {
+  const result = await submitForm({ email: '' });
+  expect(result.error).toBe('Email required');
+});
+```
+
+**Verify RED**
+```bash
+$ npm test
+FAIL: expected 'Email required', got undefined
+```
+
+**GREEN**
+```typescript
+function submitForm(data: FormData) {
+  if (!data.email?.trim()) {
+    return { error: 'Email required' };
+  }
+  // ...
+}
+```
+
+**Verify GREEN**
+```bash
+$ npm test
+PASS
+```
+
+**REFACTOR**
+Extract validation for multiple fields if needed.
+
+## Verification Checklist
+
+Before marking work complete:
+
+- [ ] Every new function/method has a test
+- [ ] Watched each test fail before implementing
+- [ ] Each test failed for expected reason (feature missing, not typo)
+- [ ] Wrote minimal code to pass each test
+- [ ] All tests pass
+- [ ] Output pristine (no errors, warnings)
+- [ ] Tests use real code (mocks only if unavoidable)
+- [ ] Edge cases and errors covered
+
+Can't check all boxes? You skipped TDD. Start over.
+
+## When Stuck
+
+| Problem | Solution |
+|---------|----------|
+| Don't know how to test | Write wished-for API. Write assertion first. Ask your human partner. |
+| Test too complicated | Design too complicated. Simplify interface. |
+| Must mock everything | Code too coupled. Use dependency injection. |
+| Test setup huge | Extract helpers. Still complex? Simplify design. |
+
+## Debugging Integration
+
+Bug found? Write failing test reproducing it. Follow TDD cycle. Test proves fix and prevents regression.
+
+Never fix bugs without a test.
+
+## Testing Anti-Patterns
+
+When adding mocks or test utilities, read @testing-anti-patterns.md to avoid common pitfalls:
+- Testing mock behavior instead of real behavior
+- Adding test-only methods to production classes
+- Mocking without understanding dependencies
+
+## Final Rule
+
+```
+Production code → test exists and failed first
+Otherwise → not TDD
+```
+
+No exceptions without your human partner's permission.

--- a/.claude/skills/test-driven-development/testing-anti-patterns.md
+++ b/.claude/skills/test-driven-development/testing-anti-patterns.md
@@ -1,0 +1,299 @@
+# Testing Anti-Patterns
+
+**Load this reference when:** writing or changing tests, adding mocks, or tempted to add test-only methods to production code.
+
+## Overview
+
+Tests must verify real behavior, not mock behavior. Mocks are a means to isolate, not the thing being tested.
+
+**Core principle:** Test what the code does, not what the mocks do.
+
+**Following strict TDD prevents these anti-patterns.**
+
+## The Iron Laws
+
+```
+1. NEVER test mock behavior
+2. NEVER add test-only methods to production classes
+3. NEVER mock without understanding dependencies
+```
+
+## Anti-Pattern 1: Testing Mock Behavior
+
+**The violation:**
+```typescript
+// ❌ BAD: Testing that the mock exists
+test('renders sidebar', () => {
+  render(<Page />);
+  expect(screen.getByTestId('sidebar-mock')).toBeInTheDocument();
+});
+```
+
+**Why this is wrong:**
+- You're verifying the mock works, not that the component works
+- Test passes when mock is present, fails when it's not
+- Tells you nothing about real behavior
+
+**your human partner's correction:** "Are we testing the behavior of a mock?"
+
+**The fix:**
+```typescript
+// ✅ GOOD: Test real component or don't mock it
+test('renders sidebar', () => {
+  render(<Page />);  // Don't mock sidebar
+  expect(screen.getByRole('navigation')).toBeInTheDocument();
+});
+
+// OR if sidebar must be mocked for isolation:
+// Don't assert on the mock - test Page's behavior with sidebar present
+```
+
+### Gate Function
+
+```
+BEFORE asserting on any mock element:
+  Ask: "Am I testing real component behavior or just mock existence?"
+
+  IF testing mock existence:
+    STOP - Delete the assertion or unmock the component
+
+  Test real behavior instead
+```
+
+## Anti-Pattern 2: Test-Only Methods in Production
+
+**The violation:**
+```typescript
+// ❌ BAD: destroy() only used in tests
+class Session {
+  async destroy() {  // Looks like production API!
+    await this._workspaceManager?.destroyWorkspace(this.id);
+    // ... cleanup
+  }
+}
+
+// In tests
+afterEach(() => session.destroy());
+```
+
+**Why this is wrong:**
+- Production class polluted with test-only code
+- Dangerous if accidentally called in production
+- Violates YAGNI and separation of concerns
+- Confuses object lifecycle with entity lifecycle
+
+**The fix:**
+```typescript
+// ✅ GOOD: Test utilities handle test cleanup
+// Session has no destroy() - it's stateless in production
+
+// In test-utils/
+export async function cleanupSession(session: Session) {
+  const workspace = session.getWorkspaceInfo();
+  if (workspace) {
+    await workspaceManager.destroyWorkspace(workspace.id);
+  }
+}
+
+// In tests
+afterEach(() => cleanupSession(session));
+```
+
+### Gate Function
+
+```
+BEFORE adding any method to production class:
+  Ask: "Is this only used by tests?"
+
+  IF yes:
+    STOP - Don't add it
+    Put it in test utilities instead
+
+  Ask: "Does this class own this resource's lifecycle?"
+
+  IF no:
+    STOP - Wrong class for this method
+```
+
+## Anti-Pattern 3: Mocking Without Understanding
+
+**The violation:**
+```typescript
+// ❌ BAD: Mock breaks test logic
+test('detects duplicate server', () => {
+  // Mock prevents config write that test depends on!
+  vi.mock('ToolCatalog', () => ({
+    discoverAndCacheTools: vi.fn().mockResolvedValue(undefined)
+  }));
+
+  await addServer(config);
+  await addServer(config);  // Should throw - but won't!
+});
+```
+
+**Why this is wrong:**
+- Mocked method had side effect test depended on (writing config)
+- Over-mocking to "be safe" breaks actual behavior
+- Test passes for wrong reason or fails mysteriously
+
+**The fix:**
+```typescript
+// ✅ GOOD: Mock at correct level
+test('detects duplicate server', () => {
+  // Mock the slow part, preserve behavior test needs
+  vi.mock('MCPServerManager'); // Just mock slow server startup
+
+  await addServer(config);  // Config written
+  await addServer(config);  // Duplicate detected ✓
+});
+```
+
+### Gate Function
+
+```
+BEFORE mocking any method:
+  STOP - Don't mock yet
+
+  1. Ask: "What side effects does the real method have?"
+  2. Ask: "Does this test depend on any of those side effects?"
+  3. Ask: "Do I fully understand what this test needs?"
+
+  IF depends on side effects:
+    Mock at lower level (the actual slow/external operation)
+    OR use test doubles that preserve necessary behavior
+    NOT the high-level method the test depends on
+
+  IF unsure what test depends on:
+    Run test with real implementation FIRST
+    Observe what actually needs to happen
+    THEN add minimal mocking at the right level
+
+  Red flags:
+    - "I'll mock this to be safe"
+    - "This might be slow, better mock it"
+    - Mocking without understanding the dependency chain
+```
+
+## Anti-Pattern 4: Incomplete Mocks
+
+**The violation:**
+```typescript
+// ❌ BAD: Partial mock - only fields you think you need
+const mockResponse = {
+  status: 'success',
+  data: { userId: '123', name: 'Alice' }
+  // Missing: metadata that downstream code uses
+};
+
+// Later: breaks when code accesses response.metadata.requestId
+```
+
+**Why this is wrong:**
+- **Partial mocks hide structural assumptions** - You only mocked fields you know about
+- **Downstream code may depend on fields you didn't include** - Silent failures
+- **Tests pass but integration fails** - Mock incomplete, real API complete
+- **False confidence** - Test proves nothing about real behavior
+
+**The Iron Rule:** Mock the COMPLETE data structure as it exists in reality, not just fields your immediate test uses.
+
+**The fix:**
+```typescript
+// ✅ GOOD: Mirror real API completeness
+const mockResponse = {
+  status: 'success',
+  data: { userId: '123', name: 'Alice' },
+  metadata: { requestId: 'req-789', timestamp: 1234567890 }
+  // All fields real API returns
+};
+```
+
+### Gate Function
+
+```
+BEFORE creating mock responses:
+  Check: "What fields does the real API response contain?"
+
+  Actions:
+    1. Examine actual API response from docs/examples
+    2. Include ALL fields system might consume downstream
+    3. Verify mock matches real response schema completely
+
+  Critical:
+    If you're creating a mock, you must understand the ENTIRE structure
+    Partial mocks fail silently when code depends on omitted fields
+
+  If uncertain: Include all documented fields
+```
+
+## Anti-Pattern 5: Integration Tests as Afterthought
+
+**The violation:**
+```
+✅ Implementation complete
+❌ No tests written
+"Ready for testing"
+```
+
+**Why this is wrong:**
+- Testing is part of implementation, not optional follow-up
+- TDD would have caught this
+- Can't claim complete without tests
+
+**The fix:**
+```
+TDD cycle:
+1. Write failing test
+2. Implement to pass
+3. Refactor
+4. THEN claim complete
+```
+
+## When Mocks Become Too Complex
+
+**Warning signs:**
+- Mock setup longer than test logic
+- Mocking everything to make test pass
+- Mocks missing methods real components have
+- Test breaks when mock changes
+
+**your human partner's question:** "Do we need to be using a mock here?"
+
+**Consider:** Integration tests with real components often simpler than complex mocks
+
+## TDD Prevents These Anti-Patterns
+
+**Why TDD helps:**
+1. **Write test first** → Forces you to think about what you're actually testing
+2. **Watch it fail** → Confirms test tests real behavior, not mocks
+3. **Minimal implementation** → No test-only methods creep in
+4. **Real dependencies** → You see what the test actually needs before mocking
+
+**If you're testing mock behavior, you violated TDD** - you added mocks without watching test fail against real code first.
+
+## Quick Reference
+
+| Anti-Pattern | Fix |
+|--------------|-----|
+| Assert on mock elements | Test real component or unmock it |
+| Test-only methods in production | Move to test utilities |
+| Mock without understanding | Understand dependencies first, mock minimally |
+| Incomplete mocks | Mirror real API completely |
+| Tests as afterthought | TDD - tests first |
+| Over-complex mocks | Consider integration tests |
+
+## Red Flags
+
+- Assertion checks for `*-mock` test IDs
+- Methods only called in test files
+- Mock setup is >50% of test
+- Test fails when you remove mock
+- Can't explain why mock is needed
+- Mocking "just to be safe"
+
+## The Bottom Line
+
+**Mocks are tools to isolate, not things to test.**
+
+If TDD reveals you're testing mock behavior, you've gone wrong.
+
+Fix: Test real behavior or question why you're mocking at all.

--- a/docs/work/done/000011-skill-hook-port/00_issue.md
+++ b/docs/work/done/000011-skill-hook-port/00_issue.md
@@ -1,0 +1,55 @@
+# chore: MIRAI 프로젝트에서 스킬 4종 + 훅 1종 이식
+
+## 목적
+MIRAI 프로젝트의 .claude/skills와 .claude/hooks에서 유용한 스킬 4종과 훅 1종을 이식하여 개발 품질과 자동화를 강화한다.
+
+## 배경
+MIRAI에는 41개 스킬이 있으나, 본 프로젝트 도메인에 맞는 범용 스킬만 선별했다. 프론트엔드/마케팅/MIRAI 전용 스킬은 제외.
+
+## 완료 기준
+- [x] skill-activation-prompt 훅이 UserPromptSubmit에 등록되어 키워드 감지 시 스킬 자동 제안됨
+- [x] 스킬 4종이 `.claude/skills/`에 존재하고 정상 동작
+  - database-schema-design (Snowflake SQL 문법에 맞게 커스터마이징)
+  - git-commit (Conventional Commits 자동 분석·생성)
+  - test-driven-development (TDD Red-Green-Refactor 강제)
+  - security-best-practices (Snowflake RBAC/네트워크 정책 반영)
+- [x] skill-rules.json 생성 (Snowflake 도메인에 맞는 트리거 키워드 정의)
+- [x] 각 스킬 디렉토리에 .ai.md 파일 존재
+- [x] .claude/hooks/.ai.md 최신화
+
+## 구현 플랜
+1. `.claude/skills/` 디렉토리 생성 + `skill-rules.json` 작성
+2. skill-activation-prompt 훅 이식 (.sh + .ts) + settings.json에 UserPromptSubmit 훅 등록
+3. 스킬 4종 이식 및 커스터마이징
+   - database-schema-design → Snowflake SQL 반영 (VARIANT, CLUSTER BY, COPY INTO 등)
+   - git-commit → 그대로 이식
+   - test-driven-development → 그대로 이식
+   - security-best-practices → Snowflake 보안 맥락 반영 (RBAC, 네트워크 정책, 데이터 마스킹 등)
+4. 각 스킬 디렉토리에 .ai.md 작성 + .claude/hooks/.ai.md 업데이트
+
+## 참고
+- 원본 위치: `D:\project\T아카데미\MIRAI\MIRAI\.claude\skills\`
+- secret-filter.sh는 이미 동일하므로 제외
+- 프론트엔드/마케팅 관련 스킬은 도메인 불일치로 제외
+
+## 개발 체크리스트
+- [x] 해당 디렉토리 .ai.md 최신화
+
+
+## 작업 내역
+
+### 2026-04-07
+
+**현황**: 5/5 완료
+**완료된 항목**:
+- skill-activation-prompt 훅 이식 (.sh + .ts) + settings.json UserPromptSubmit 등록
+- 스킬 4종 포팅: git-commit, tdd as-is / database-schema-design, security-best-practices Snowflake 전용 신규 저작
+- skill-rules.json 생성 (4개 스킬 Snowflake 도메인 트리거 정의)
+- 각 스킬 디렉토리 + skills 루트 .ai.md 작성 (5개 신규)
+- .claude/hooks/.ai.md 최신화 (skill-activation-prompt 설명 추가)
+**미완료 항목**:
+- (없음)
+**변경 파일**: 16개
+- 신규: 스킬 4종 SKILL.md + testing-anti-patterns.md + .ai.md 5개 + skill-rules.json + skill-activation-prompt.sh/.ts
+- 수정: settings.json, hooks/.ai.md
+- 문서: 00_issue.md, 01_plan.md (ralplan 합의 완료)

--- a/docs/work/done/000011-skill-hook-port/01_plan.md
+++ b/docs/work/done/000011-skill-hook-port/01_plan.md
@@ -1,0 +1,180 @@
+# [#11] MIRAI 프로젝트에서 스킬 4종 + 훅 1종 이식 — 구현 계획
+
+> 작성: 2026-04-07
+
+---
+
+## 완료 기준
+
+- [ ] skill-activation-prompt 훅이 UserPromptSubmit에 등록되어 키워드 감지 시 스킬 자동 제안됨
+- [ ] 스킬 4종이 `.claude/skills/`에 존재하고 정상 동작
+  - database-schema-design (Snowflake SQL 문법에 맞게 커스터마이징)
+  - git-commit (Conventional Commits 자동 분석·생성)
+  - test-driven-development (TDD Red-Green-Refactor 강제)
+  - security-best-practices (Snowflake RBAC/네트워크 정책 반영)
+- [ ] skill-rules.json 생성 (Snowflake 도메인에 맞는 트리거 키워드 정의)
+- [ ] 각 스킬 디렉토리에 .ai.md 파일 존재
+- [ ] .claude/hooks/.ai.md 최신화
+
+---
+
+## 구현 계획
+
+> Ralplan 합의 완료 (Planner → Architect → Critic). 2026-04-07
+
+### RALPLAN-DR Summary
+
+**Principles**
+1. 최소 변경 원칙 — 원본 범용 부분은 그대로, Snowflake 전용만 커스터마이징
+2. 자기 설명적 구조 — 모든 디렉토리에 `.ai.md` 포함
+3. 점진적 활성화 — 훅과 스킬을 독립 단위로 포팅, 기존 기능 영향 없음
+4. 도메인 정합성 — Snowflake SQL/보안 모델에 맞지 않는 내용 제거·대체
+
+**Decision Drivers**
+1. tsx v4.21.0 + Node v25.6.0 확인됨 → TS 훅 그대로 사용 가능
+2. 커스터마이징 범위: database-schema-design, security-best-practices 2종은 **신규 저작** (원본은 구조 템플릿으로만 참고)
+3. settings.json 병합: 기존 PostToolUse 유지 + UserPromptSubmit 추가 (충돌 없음)
+
+**ADR**: TS 훅(Option A) 채택. Bash-only(Option B)는 JSON 파싱 불안정·regex 매칭 난이도로 배제. Python3 하이브리드는 검토했으나, 검증된 TS 코드 재사용이 더 효율적.
+
+---
+
+### Step 1: 스킬 디렉토리 구조 생성
+
+```
+.claude/skills/
+  database-schema-design/
+  git-commit/
+  test-driven-development/
+  security-best-practices/
+```
+
+- AC: `ls .claude/skills/` → 4개 디렉토리
+
+---
+
+### Step 2: As-is 스킬 포팅 (git-commit, test-driven-development)
+
+| 소스 (MIRAI) | 대상 |
+|------|------|
+| `.claude/skills/git-commit/SKILL.md` (125줄) | `.claude/skills/git-commit/SKILL.md` |
+| `.claude/skills/test-driven-development/SKILL.md` (372줄) | `.claude/skills/test-driven-development/SKILL.md` |
+| `.claude/skills/test-driven-development/testing-anti-patterns.md` (300줄) | `.claude/skills/test-driven-development/testing-anti-patterns.md` |
+
+- 내용 변경 없이 복사
+- SKILL.toon 파일은 포팅하지 않음
+- 각 디렉토리에 `.ai.md` 작성
+- AC: 원본과 내용 동일 + .ai.md 존재
+
+---
+
+### Step 3: Snowflake 커스터마이징 — database-schema-design ⚠️ 신규 저작
+
+> 원본(694줄)에 PostgreSQL/MySQL/MongoDB 참조 18건, Snowflake 0건 → 단순 편집이 아닌 **Snowflake 전용 신규 저작**. 원본은 구조 템플릿(섹션 헤더, 포맷)으로만 참고.
+
+**제거**: PostgreSQL/MySQL/MongoDB/SQLite/ORM(Prisma) 전용 내용
+**추가**:
+- 데이터 타입: `VARIANT`, `OBJECT`, `ARRAY`, `GEOGRAPHY`, `TIMESTAMP_LTZ/NTZ/TZ`
+- 테이블 설계: `CLUSTER BY`, `TRANSIENT TABLE`, `TEMPORARY TABLE`
+- 데이터 로딩: `COPY INTO`, `STAGE`, `FILE FORMAT`, `PIPE`
+- 고급 기능: `Time Travel`, `Streams`, `Tasks`, `Dynamic Tables`
+- 스키마 구조: `DATABASE > SCHEMA > TABLE` 3-tier 네임스페이스
+- 성능: `RESULT_USE_CACHING`, Micro-partition pruning, Materialized Views
+
+- AC: Snowflake 키워드 10+ 포함, PostgreSQL/MySQL/MongoDB 코드 블록 없음, .ai.md 존재
+
+---
+
+### Step 4: Snowflake 커스터마이징 — security-best-practices ⚠️ 신규 저작
+
+> 원본(288줄)에 Express/Helmet/CORS/XSS/CSRF 참조 19건 → 웹 보안과 Snowflake 데이터 플랫폼 보안은 완전히 다른 도메인. **Snowflake 전용 신규 저작**.
+
+**제거**: Express.js/Helmet/CORS/CSP/XSS/CSRF 웹 보안 섹션
+**추가**:
+- RBAC: `ROLE`, `GRANT`, `REVOKE`, 역할 계층, `SECURITYADMIN`/`SYSADMIN` 분리
+- Network Policies: IP 화이트리스트, `CREATE NETWORK POLICY`
+- Data Masking: `CREATE MASKING POLICY`, 동적 데이터 마스킹
+- Row Access Policies: `CREATE ROW ACCESS POLICY`
+- MFA: `ALTER USER ... SET REQUIRE_MFA = TRUE`
+- 암호화: AES-256, Tri-Secret Secure
+- 감사: `ACCOUNT_USAGE`, `ACCESS_HISTORY`, `LOGIN_HISTORY`
+- 세션: `SESSION_POLICY`, 유휴 타임아웃
+
+- AC: Snowflake 보안 키워드 10+ 포함, Express.js/Helmet/CORS 없음, .ai.md 존재
+
+---
+
+### Step 5: skill-activation-prompt 훅 + skill-rules.json + settings.json
+
+**5-1. 훅 파일 복사**
+
+| 소스 (MIRAI) | 대상 |
+|------|------|
+| `.claude/hooks/skill-activation-prompt.sh` | `.claude/hooks/skill-activation-prompt.sh` |
+| `.claude/hooks/skill-activation-prompt.ts` | `.claude/hooks/skill-activation-prompt.ts` |
+
+- `.sh`에 **tsx 가드 추가** (Architect 조건):
+  ```bash
+  command -v npx >/dev/null 2>&1 && npx tsx --version >/dev/null 2>&1 || { echo "tsx not found, skipping skill activation"; exit 0; }
+  ```
+- `.ts`의 `findRulesPath()`는 `CLAUDE_PROJECT_DIR` 기반 — 변경 불필요
+
+**5-2. skill-rules.json 생성** (`.claude/skills/skill-rules.json`)
+
+4개 스킬만 정의 (MIRAI 잔여 트리거 포함 금지 — Express, MUI, Prisma 등 절대 불포함):
+- `database-schema-design`: type=domain, priority=high, 키워드=["스키마","schema","snowflake","variant","cluster by","copy into","stage","time travel","데이터 모델링","ERD"]
+- `git-commit`: type=domain, priority=medium, 키워드=["commit","커밋","conventional commit"]
+- `test-driven-development`: type=guardrail, priority=high, 키워드=["tdd","test first","테스트 먼저","red green refactor"]
+- `security-best-practices`: type=domain, priority=high, 키워드=["보안","security","rbac","masking","network policy","row access","권한","role","grant"]
+
+**5-3. settings.json 업데이트** — UserPromptSubmit 훅 추가 (permissions/enabledPlugins 변경 금지)
+
+- AC: .sh+.ts 존재, skill-rules.json 유효 JSON, settings.json에 UserPromptSubmit 등록, 기존 PostToolUse 유지
+
+---
+
+### Step 6: 문서 최신화
+
+| 파일 | 작업 |
+|------|------|
+| `.claude/skills/.ai.md` | 신규 — skills 디렉토리 설명 |
+| `.claude/skills/database-schema-design/.ai.md` | 신규 |
+| `.claude/skills/git-commit/.ai.md` | 신규 |
+| `.claude/skills/test-driven-development/.ai.md` | 신규 |
+| `.claude/skills/security-best-practices/.ai.md` | 신규 |
+| `.claude/hooks/.ai.md` | 수정 — skill-activation-prompt 훅 추가 기술 |
+
+- AC: 6개 .ai.md (5 신규 + 1 수정), 모두 한국어
+
+---
+
+### Guardrails
+
+**Must Have**
+- 기존 secret-filter.sh PostToolUse 훅 동작 유지
+- settings.json의 permissions 섹션 변경 없음
+- 모든 스킬 디렉토리에 .ai.md 파일 존재
+- database-schema-design에 Snowflake 전용 내용 (VARIANT, CLUSTER BY, Time Travel 등)
+- security-best-practices에 Snowflake 보안 내용 (RBAC, Network Policies 등)
+- skill-rules.json에 Snowflake 도메인 키워드만 반영
+- skill-activation-prompt.sh에 tsx 가드 코드 포함
+
+**Must NOT Have**
+- PostgreSQL/MySQL/MongoDB 전용 내용을 database-schema-design에 남김
+- Express.js/Helmet/CORS 전용 내용을 security-best-practices에 남김
+- settings.json의 permissions 또는 enabledPlugins 변경
+- 원본 MIRAI 프로젝트 파일 수정
+- skill-rules.json에 MIRAI 전용 트리거 (Express, MUI, Prisma 등) 포함
+
+---
+
+### 실행 순서 (의존성)
+
+```
+Step 1 (디렉토리 생성)
+  ├── Step 2 (as-is 포팅) ─── 병렬 가능
+  ├── Step 3 (DB 스킬 신규 저작) ── 병렬 가능
+  └── Step 4 (보안 스킬 신규 저작) ── 병렬 가능
+       └── Step 5 (훅 + rules + settings) ── Step 2,3,4 완료 후
+            └── Step 6 (문서) ── Step 5 완료 후
+```


### PR DESCRIPTION
## 이슈 배경
MIRAI 프로젝트의 .claude/skills와 .claude/hooks에서 유용한 스킬 4종과 훅 1종을 이식하여 개발 품질과 자동화를 강화한다. MIRAI에는 41개 스킬이 있으나, 본 프로젝트(Snowflake 기반 교육 AI) 도메인에 맞는 범용 스킬만 선별했다.

## 완료 기준 (AC)
- [x] skill-activation-prompt 훅이 UserPromptSubmit에 등록되어 키워드 감지 시 스킬 자동 제안됨
- [x] 스킬 4종이 `.claude/skills/`에 존재하고 정상 동작
  - database-schema-design (Snowflake SQL 문법에 맞게 커스터마이징)
  - git-commit (Conventional Commits 자동 분석·생성)
  - test-driven-development (TDD Red-Green-Refactor 강제)
  - security-best-practices (Snowflake RBAC/네트워크 정책 반영)
- [x] skill-rules.json 생성 (Snowflake 도메인에 맞는 트리거 키워드 정의)
- [x] 각 스킬 디렉토리에 .ai.md 파일 존재
- [x] .claude/hooks/.ai.md 최신화

## 작업 내역
- skill-activation-prompt 훅 이식 (.sh + .ts) + settings.json UserPromptSubmit 등록
- 스킬 4종 포팅: git-commit, tdd as-is / database-schema-design, security-best-practices Snowflake 전용 신규 저작
- skill-rules.json 생성 (4개 스킬 Snowflake 도메인 트리거 정의)
- .ai.md 6개 작성 (5개 신규 + hooks/.ai.md 수정)
- tsx 가드 최적화 (npx tsx --version → command -v npx) + 에러 로깅 추가

Closes #11