### PR TITLE
feat: 수업 초안에서 다음 세션 자동 생성 (#62)

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -2147,76 +2147,60 @@
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.67.3",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.67.3.tgz",
-      "integrity": "sha512-NJDaW8yXs49xMvWVOkSIr8j46jf+tYHV0wHhrwOaLLMZSFO4g6kKAf+MfzQ2RaD06OCUkUHIzctLAxjTgEVpzw==",
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.0.tgz",
+      "integrity": "sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.4.tgz",
-      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.103.0.tgz",
+      "integrity": "sha512-YrneV2NjskUkkmkZ2Jt2n3elBgbWzV4Y1M9MM370z2Zd5ZPFqFbY8KIoPwuNjtAGE9YrpKBxnbZqeF07BiN9Og==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/node-fetch": {
-      "version": "2.6.15",
-      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
-      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "tslib": "2.8.1"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@supabase/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
       "license": "MIT"
     },
-    "node_modules/@supabase/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@supabase/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.17.7.tgz",
-      "integrity": "sha512-aOzOYaTADm/dVTNksyqv9KsbhVa1gHz1Hoxb2ZEF2Ed9H7qlWOfptECQWmkEmrrFjtNaiPrgiSaPECvzI/seDA==",
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.103.0.tgz",
+      "integrity": "sha512-rC3sRxYdPZymkp2CZR1MiNQgbOleD01bGsW8VxEKRR5nMkLZ1NgAS1QTQf78Wh30czFyk505ZYr9Od8/mWT2TA==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.2.tgz",
-      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.103.0.tgz",
+      "integrity": "sha512-gcPtXzZ6izyyBVf2of7K3dEt8CScPJn8VcSlQq6oWL9QoE1kqfQl0oFrOMHd5qrcADewxI7OxxosLB8W4XqtIQ==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14",
-        "@types/phoenix": "^1.5.4",
-        "@types/ws": "^8.5.10",
-        "ws": "^8.18.0"
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/ssr": {
@@ -2233,26 +2217,32 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
-      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.103.0.tgz",
+      "integrity": "sha512-DHmlvdAXwtOmZNbkIZi4lkobPR3XjIzoOgzoz5duMf6G+sDeY015YrzMJCnqdccuYr7X5x4yYuSwF//RoN2dvQ==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.47.10",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.47.10.tgz",
-      "integrity": "sha512-vJfPF820Ho5WILYHfKiBykDQ1SB9odTHrRZ0JxHfuLMC8GRvv21YLkUZQK7/rSVCkLvD6/ZwMWaOAfdUd//guw==",
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.0.tgz",
+      "integrity": "sha512-j/6q5+LtXbR/YOLSLhy7Na74RD1cV2v+KwIIuuqMEjk1JpLEEyu0ynwDHpGoxMncDQl+R5FogaVqZm+85lZvtw==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.67.3",
-        "@supabase/functions-js": "2.4.4",
-        "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.17.7",
-        "@supabase/realtime-js": "2.11.2",
-        "@supabase/storage-js": "2.7.1"
+        "@supabase/auth-js": "2.103.0",
+        "@supabase/functions-js": "2.103.0",
+        "@supabase/postgrest-js": "2.103.0",
+        "@supabase/realtime-js": "2.103.0",
+        "@supabase/storage-js": "2.103.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@swc/counter": {
@@ -2482,12 +2472,6 @@
         "@types/node": "*",
         "form-data": "^4.0.4"
       }
-    },
-    "node_modules/@types/phoenix": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
-      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
-      "license": "MIT"
     },
     "node_modules/@types/qrcode": {
       "version": "1.5.6",
@@ -5957,6 +5941,15 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {

--- a/apps/web/src/app/api/sessions/from-draft/preview/route.ts
+++ b/apps/web/src/app/api/sessions/from-draft/preview/route.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+import Anthropic from '@anthropic-ai/sdk';
+import { createClient } from '@/lib/supabase/server';
+import { buildDraftQuestionsPrompt, DRAFT_QUESTIONS_TOOL } from '@/lib/prompts/draft-questions';
+import type { InsightResult } from '@/lib/prompts/insights';
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const bodySchema = z.object({ source_session_id: z.string().uuid() });
+
+export interface QuestionPreview {
+  content: string;
+  options: [string, string, string, string];
+  correct_answer: number;
+}
+
+export interface PreviewResponse {
+  title: string;
+  questions: QuestionPreview[];
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  // 1. 인증
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return Response.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+
+  // 2. Body 검증
+  let source_session_id: string;
+  try {
+    const parsed = bodySchema.parse(await request.json());
+    source_session_id = parsed.source_session_id;
+  } catch {
+    return Response.json({ error: 'VALIDATION_ERROR' }, { status: 400 });
+  }
+
+  // 3. 세션 조회 + 소유권 확인
+  const { data: session } = await supabase
+    .from('sessions')
+    .select('id, teacher_id')
+    .eq('id', source_session_id)
+    .single() as { data: { id: string; teacher_id: string } | null; error: unknown };
+
+  if (!session || session.teacher_id !== user.id)
+    return Response.json({ error: 'FORBIDDEN' }, { status: 403 });
+
+  // 4+5. 수업 초안 + 인사이트 병렬 조회
+  const [{ data: draft }, { data: insightRow }] = await Promise.all([
+    supabase
+      .from('class_drafts')
+      .select('content')
+      .eq('session_id', source_session_id)
+      .maybeSingle() as Promise<{ data: { content: string } | null; error: unknown }>,
+    supabase
+      .from('ai_insights')
+      .select('insights')
+      .eq('session_id', source_session_id)
+      .maybeSingle() as Promise<{ data: { insights: unknown } | null; error: unknown }>,
+  ]);
+
+  if (!draft) return Response.json({ error: 'NO_DRAFT' }, { status: 404 });
+  if (!insightRow) return Response.json({ error: 'NO_INSIGHTS' }, { status: 404 });
+
+  const insights = insightRow.insights as InsightResult;
+  const weakConcepts = insights.top_weak_concepts ?? [];
+
+  // 6. Claude tool use 호출
+  const { system, user: userMsg } = buildDraftQuestionsPrompt(draft.content, weakConcepts);
+
+  let result: PreviewResponse;
+  try {
+    const response = await client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 2048,
+      system,
+      tools: [DRAFT_QUESTIONS_TOOL],
+      tool_choice: { type: 'tool', name: 'generate_session_questions' },
+      messages: [{ role: 'user', content: userMsg }],
+    });
+
+    const toolBlock = response.content.find((b) => b.type === 'tool_use');
+    if (!toolBlock || toolBlock.type !== 'tool_use') {
+      return Response.json({ error: 'CLAUDE_ERROR' }, { status: 500 });
+    }
+
+    const input = toolBlock.input as { title: string; questions: QuestionPreview[] };
+    result = { title: input.title, questions: input.questions };
+  } catch (err) {
+    console.error('[from-draft/preview] Claude error:', err);
+    return Response.json({ error: 'CLAUDE_ERROR' }, { status: 500 });
+  }
+
+  // 7. 반환 (DB 저장 없음)
+  return Response.json(result);
+}

--- a/apps/web/src/app/api/sessions/from-draft/route.ts
+++ b/apps/web/src/app/api/sessions/from-draft/route.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+import { createClient } from '@/lib/supabase/server';
+import { generateUniqueJoinCode } from '@/lib/join-code';
+
+const questionSchema = z.object({
+  content: z.string().min(1),
+  options: z.tuple([z.string(), z.string(), z.string(), z.string()]),
+  correct_answer: z.number().int().min(0).max(3),
+});
+
+const bodySchema = z.object({
+  source_session_id: z.string().uuid(),
+  title: z.string().min(1),
+  questions: z.array(questionSchema).min(3).max(5),
+});
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  // 1. 인증
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return Response.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+
+  // 2. Body 검증
+  let body: z.infer<typeof bodySchema>;
+  try {
+    body = bodySchema.parse(await request.json());
+  } catch {
+    return Response.json({ error: 'VALIDATION_ERROR' }, { status: 400 });
+  }
+
+  const { source_session_id, title, questions } = body;
+
+  // 3. 소유권 확인 + subject/grade 가져오기
+  const { data: sourceSession } = await supabase
+    .from('sessions')
+    .select('id, teacher_id, subject, grade')
+    .eq('id', source_session_id)
+    .single() as { data: { id: string; teacher_id: string; subject: string; grade: string } | null; error: unknown };
+
+  if (!sourceSession || sourceSession.teacher_id !== user.id)
+    return Response.json({ error: 'FORBIDDEN' }, { status: 403 });
+
+  // 4. join_code 생성
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const join_code = await generateUniqueJoinCode(supabase as any);
+
+  // 5. 세션 INSERT
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = supabase as any;
+  const { data: newSession, error: sessionError } = await sb
+    .from('sessions')
+    .insert({
+      teacher_id: user.id,
+      title,
+      subject: sourceSession.subject,
+      grade: sourceSession.grade,
+      join_code,
+      status: 'draft',
+    })
+    .select('id')
+    .single() as { data: { id: string } | null; error: { message: string } | null };
+
+  if (sessionError || !newSession) {
+    return Response.json({ error: 'DB_ERROR', details: sessionError?.message }, { status: 500 });
+  }
+
+  // 6. 문항 bulk INSERT
+  const questionRows = questions.map((q, i) => ({
+    session_id: newSession.id,
+    content: q.content,
+    options: q.options,
+    correct_answer: q.correct_answer,
+    question_order: i,
+  }));
+
+  const { error: questionsError } = await sb.from('questions').insert(questionRows) as { error: { message: string } | null };
+
+  if (questionsError) {
+    // 롤백: 세션 삭제
+    const { error: rollbackErr } = await sb.from('sessions').delete().eq('id', newSession.id);
+    if (rollbackErr) console.error('[from-draft] rollback failed', { sessionId: newSession.id, rollbackErr });
+    return Response.json({ error: 'DB_ERROR', details: questionsError.message }, { status: 500 });
+  }
+
+  return Response.json({ id: newSession.id }, { status: 201 });
+}

--- a/apps/web/src/app/teacher/sessions/[id]/insights/page.tsx
+++ b/apps/web/src/app/teacher/sessions/[id]/insights/page.tsx
@@ -137,7 +137,9 @@ export default function InsightsPage({ params }: Props) {
       )}
 
       {/* 수업 초안 패널 */}
-      {draftContent && <ClassDraftPanel content={draftContent} />}
+      {draftContent && sessionId && (
+        <ClassDraftPanel content={draftContent} sourceSessionId={sessionId} />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/dashboard/ClassDraftPanel.tsx
+++ b/apps/web/src/components/dashboard/ClassDraftPanel.tsx
@@ -1,15 +1,20 @@
 'use client';
 
 import React from 'react';
+import { useRouter } from 'next/navigation';
 import Markdown from 'react-markdown';
 import { copyToClipboard } from '@/lib/clipboard';
+import { DraftSessionConfirmModal } from './DraftSessionConfirmModal';
 
 interface Props {
   content: string;
+  sourceSessionId: string;
 }
 
-export function ClassDraftPanel({ content }: Props) {
+export function ClassDraftPanel({ content, sourceSessionId }: Props) {
+  const router = useRouter();
   const [copied, setCopied] = React.useState(false);
+  const [modalOpen, setModalOpen] = React.useState(false);
 
   const handleCopy = async () => {
     const success = await copyToClipboard(content);
@@ -19,20 +24,40 @@ export function ClassDraftPanel({ content }: Props) {
     }
   };
 
+  const handleCreated = (sessionId: string) => {
+    setModalOpen(false);
+    router.push(`/teacher/sessions/${sessionId}/edit`);
+  };
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">수업 초안</h2>
-        <button
-          onClick={handleCopy}
-          className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 active:bg-gray-100"
-        >
-          {copied ? '복사됨!' : '복사'}
-        </button>
+        <div className="flex gap-2">
+          <button
+            onClick={handleCopy}
+            className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 active:bg-gray-100"
+          >
+            {copied ? '복사됨!' : '복사'}
+          </button>
+          <button
+            onClick={() => setModalOpen(true)}
+            className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-blue-700"
+          >
+            AI 세션 생성
+          </button>
+        </div>
       </div>
       <div className="prose prose-sm max-w-none rounded-lg border bg-white p-4">
         <Markdown>{content}</Markdown>
       </div>
+
+      <DraftSessionConfirmModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        sourceSessionId={sourceSessionId}
+        onCreated={handleCreated}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/dashboard/DraftSessionConfirmModal.tsx
+++ b/apps/web/src/components/dashboard/DraftSessionConfirmModal.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import React from 'react';
+import type { PreviewResponse, QuestionPreview } from '@/app/api/sessions/from-draft/preview/route';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  sourceSessionId: string;
+  onCreated: (sessionId: string) => void;
+}
+
+export function DraftSessionConfirmModal({ open, onClose, sourceSessionId, onCreated }: Props) {
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [preview, setPreview] = React.useState<PreviewResponse | null>(null);
+  const [title, setTitle] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+  // 같은 세션에 대한 재오픈 시 재호출 방지
+  const cachedIdRef = React.useRef<string | null>(null);
+
+  // open이 true가 될 때 preview 호출 (캐시 + AbortController)
+  React.useEffect(() => {
+    if (!open) return;
+    if (cachedIdRef.current === sourceSessionId && preview) return;
+
+    const ac = new AbortController();
+    setPreview(null);
+    setError(null);
+    setTitle('');
+    setLoading(true);
+
+    fetch('/api/sessions/from-draft/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source_session_id: sourceSessionId }),
+      signal: ac.signal,
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          const json = await res.json().catch(() => ({}));
+          setError(json.error ?? '미리보기 생성에 실패했습니다.');
+          return;
+        }
+        const data: PreviewResponse = await res.json();
+        cachedIdRef.current = sourceSessionId;
+        setPreview(data);
+        setTitle(data.title);
+      })
+      .catch((err) => {
+        if (err instanceof Error && err.name === 'AbortError') return;
+        setError('네트워크 오류가 발생했습니다.');
+      })
+      .finally(() => setLoading(false));
+
+    return () => ac.abort();
+  }, [open, sourceSessionId]);
+
+  async function handleCreate() {
+    if (!preview || submitting) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch('/api/sessions/from-draft', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          source_session_id: sourceSessionId,
+          title,
+          questions: preview.questions,
+        }),
+      });
+
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        setError(json.error ?? '세션 생성에 실패했습니다.');
+        return;
+      }
+
+      const data = await res.json();
+      onCreated(data.id as string);
+    } catch {
+      setError('네트워크 오류가 발생했습니다.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="relative w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl bg-white p-6 shadow-xl">
+        {/* 헤더 */}
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-gray-900">AI 세션 생성 미리보기</h2>
+          <button
+            onClick={onClose}
+            className="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+            aria-label="닫기"
+          >
+            <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+              <path
+                fillRule="evenodd"
+                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* 로딩 */}
+        {loading && (
+          <div className="flex flex-col items-center justify-center py-16 gap-3">
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-200 border-t-blue-600" />
+            <p className="text-sm text-gray-500">AI가 문항을 생성하고 있습니다...</p>
+          </div>
+        )}
+
+        {/* 에러 */}
+        {error && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 mb-4">
+            {error}
+          </div>
+        )}
+
+        {/* 미리보기 내용 */}
+        {preview && !loading && (
+          <div className="space-y-5">
+            {/* 제목 편집 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">세션 제목</label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+
+            {/* 문항 목록 */}
+            <div>
+              <p className="text-sm font-medium text-gray-700 mb-2">
+                문항 목록 ({preview.questions.length}개)
+              </p>
+              <ol className="space-y-4">
+                {preview.questions.map((q: QuestionPreview, qi: number) => (
+                  <li key={qi} className="rounded-lg border border-gray-200 p-4">
+                    <p className="text-sm font-medium text-gray-900 mb-2">
+                      {qi + 1}. {q.content}
+                    </p>
+                    <ul className="space-y-1">
+                      {q.options.map((opt: string, oi: number) => (
+                        <li
+                          key={oi}
+                          className={`rounded px-3 py-1.5 text-sm ${
+                            oi === q.correct_answer
+                              ? 'bg-green-50 text-green-800 font-medium border border-green-200'
+                              : 'text-gray-600'
+                          }`}
+                        >
+                          {oi + 1}. {opt}
+                          {oi === q.correct_answer && (
+                            <span className="ml-2 text-xs text-green-600">(정답)</span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </li>
+                ))}
+              </ol>
+            </div>
+
+            {/* 하단 버튼 */}
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                onClick={onClose}
+                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleCreate}
+                disabled={submitting || !title.trim()}
+                className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {submitting ? '생성 중...' : '세션 생성'}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/SessionDetailClient.tsx
+++ b/apps/web/src/components/dashboard/SessionDetailClient.tsx
@@ -79,7 +79,6 @@ export function SessionDetailClient({ session, questions, initialResponses }: Pr
         <span className="text-sm text-gray-500">
           총 응답 {responses.length}개
         </span>
-
       </div>
 
       {/* Response chart */}

--- a/apps/web/src/lib/prompts/draft-questions.ts
+++ b/apps/web/src/lib/prompts/draft-questions.ts
@@ -1,0 +1,77 @@
+import type { InsightResult } from './insights';
+
+/**
+ * Claude tool use를 위한 문항 생성 프롬프트 + tool schema를 반환한다.
+ */
+export const DRAFT_QUESTIONS_TOOL = {
+  name: 'generate_session_questions',
+  description:
+    '수업 초안과 취약 개념을 바탕으로 다음 세션에 사용할 4지선다 문항 3~5개를 생성한다.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      title: {
+        type: 'string',
+        description: '세션 제목 (예: "2차 방정식 심화 복습")',
+      },
+      questions: {
+        type: 'array',
+        minItems: 3,
+        maxItems: 5,
+        description: '생성할 문항 목록 (3~5개)',
+        items: {
+          type: 'object',
+          properties: {
+            content: {
+              type: 'string',
+              description: '문항 내용',
+            },
+            options: {
+              type: 'array',
+              minItems: 4,
+              maxItems: 4,
+              description: '4개의 선택지',
+              items: { type: 'string' },
+            },
+            correct_answer: {
+              type: 'integer',
+              minimum: 0,
+              maximum: 3,
+              description: '정답 인덱스 (0~3)',
+            },
+          },
+          required: ['content', 'options', 'correct_answer'],
+        },
+      },
+    },
+    required: ['title', 'questions'],
+  },
+} as const;
+
+/**
+ * 문항 생성을 위한 system / user 메시지 쌍을 반환한다.
+ *
+ * @param draftContent - 수업 초안 마크다운 텍스트
+ * @param weakConcepts - 인사이트에서 추출한 취약 개념 목록
+ */
+export function buildDraftQuestionsPrompt(
+  draftContent: string,
+  weakConcepts: InsightResult['top_weak_concepts'],
+): { system: string; user: string } {
+  const system = `당신은 경험 많은 한국 교사입니다. 주어진 수업 초안과 취약 개념을 바탕으로 학생들의 이해도를 점검할 4지선다 문항을 생성합니다.
+
+규칙:
+- 반드시 generate_session_questions 도구를 사용해 응답
+- 취약 개념(top_weak_concepts)을 중심으로 문항 출제
+- 문항 수: 3~5개
+- 각 문항은 4개의 선택지, 정답 인덱스(0~3) 포함
+- 한국어로 작성
+- 실제 수업에서 바로 사용 가능한 수준의 문항`;
+
+  const user = JSON.stringify({
+    draft_content: draftContent,
+    top_weak_concepts: weakConcepts,
+  });
+
+  return { system, user };
+}

--- a/apps/web/src/lib/prompts/insights.ts
+++ b/apps/web/src/lib/prompts/insights.ts
@@ -85,6 +85,7 @@ export function buildInsightsPrompt(
  * @throws SyntaxError - JSON 파싱 실패 시
  */
 export function parseInsightResponse(raw: string): InsightResult {
-  const parsed = JSON.parse(raw);
+  const cleaned = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
+  const parsed = JSON.parse(cleaned);
   return InsightSchema.parse(parsed);
 }

--- a/docs/ai-report/daily-log.md
+++ b/docs/ai-report/daily-log.md
@@ -572,6 +572,47 @@ Issue #31 교사 대시보드 세션 목록 + 실시간 집계 차트 구현 (IU
 
 ---
 
+### 이슈 #62 — 수업 초안에서 다음 세션 자동 생성
+
+### 사용 도구
+- Claude Code (Claude Sonnet 4.6) — ralplan(Planner/Architect/Critic 합의), executor 구현, simplify 리뷰
+
+### 주요 프롬프트 및 결과
+
+**프롬프트 1**: ralplan으로 구현 계획 수립
+- AI 응답 요약: Planner가 Option A(초안 생성 시 structured_questions 함께 반환) 제안 → Architect가 생명주기 분리 문제 지적 → Critic이 Architect synthesis 채택 권고 → 2-step API 패턴 확정
+- 채택 여부: Architect synthesis 채택 (Option A 기각)
+- 수정 내용: `/api/class-draft/generate` 기존 유지, preview/from-draft 분리
+
+**프롬프트 2**: executor로 전체 구현
+- AI 응답 요약: 5단계 구현 — prompts, preview API, from-draft API, 모달, 호출처 업데이트
+- 채택 여부: 채택
+- 수정 내용: Supabase 타입 never 이슈 → 인라인 타입 어설션으로 해결
+
+**프롬프트 3**: simplify 리뷰 후 개선
+- AI 응답 요약: draft+insights 병렬 조회, AbortController + preview 캐시, 롤백 에러 로그 추가
+- 채택 여부: 채택
+
+### AI 기여 영역
+- `apps/web/src/lib/prompts/draft-questions.ts` — Claude tool use 스키마 + 프롬프트 빌더
+- `apps/web/src/app/api/sessions/from-draft/preview/route.ts` — AI 호출 미리보기 엔드포인트 (병렬 DB 조회)
+- `apps/web/src/app/api/sessions/from-draft/route.ts` — 세션+문항 트랜잭션 삽입, 롤백 처리
+- `apps/web/src/components/dashboard/DraftSessionConfirmModal.tsx` — 미리보기 모달 (캐시, AbortController)
+- `apps/web/src/components/dashboard/ClassDraftPanel.tsx` — 버튼 + 모달 연결
+- `apps/web/src/lib/prompts/insights.ts` — 코드 펜스 제거 처리 추가
+- 충돌 해결 (rebase): SessionDetailClient.tsx
+
+### 인간 주도 영역
+- Architect synthesis 방향 최종 승인
+- 실제 브라우저에서 AI 세션 생성 플로우 검증
+- 최종 커밋·PR 승인
+
+### 오늘의 인사이트
+- 마크다운(교안)과 structured_questions(퀴즈 스키마)는 생성 시점만 같을 뿐 생명주기가 다름 — 한 API에 묶으면 파싱 실패가 UI까지 전파됨
+- Preview(AI 호출, 미리보기) → Confirm(DB만, 원자적 생성) 2-step 패턴이 UX와 신뢰성 모두 확보
+
+---
+
 ## 04/11 (토) AI 활용 로그
 
 ### 사용 도구

--- a/docs/work/done/000062-draft-session/00_issue.md
+++ b/docs/work/done/000062-draft-session/00_issue.md
@@ -1,0 +1,48 @@
+# feat: 수업 초안에서 다음 세션 자동 생성
+
+## 사용자 관점 목표
+교사는 AI 인사이트와 수업 초안 생성 후, 별도 입력 없이 \"AI 세션 생성\" 버튼 하나로 다음 수업 퀴즈 세션과 문항을 자동으로 세팅할 수 있다.
+
+## 배경
+현재 수업 초안 생성 후 교사가 직접 새 세션을 만들고 문항을 수동 입력해야 한다. 인사이트 기반으로 자동 생성하면 흐름이 끊기지 않는다.
+
+## 완료 기준
+- [x] 수업 초안 생성 후 "AI 세션 생성" 버튼이 ClassDraftPanel 하단에 표시된다
+- [x] 버튼 클릭 시 AI가 추출한 세션 제목·문항·정답 목록을 미리 볼 수 있는 확인 모달이 열린다
+- [x] 확인 클릭 시 세션과 문항이 자동 생성되고 편집 페이지(`/teacher/sessions/{id}/edit`)로 이동한다
+- [x] 초안의 weak_concepts 기반으로 문항 3~5개를 자동 추출·등록한다
+
+## 구현 플랜
+1. `/api/class-draft/generate` 응답에 structured questions 추가 (제목·문항·정답)
+2. `ClassDraftPanel`에 "AI 세션 생성" 버튼 + 확인 모달 추가
+3. `/api/sessions/from-draft` 엔드포인트 — 세션 + 문항 일괄 생성
+4. 생성 후 `/teacher/sessions/{id}/edit` 리디렉트
+
+## 개발 체크리스트
+- [ ] 테스트 코드 포함
+- [ ] 해당 디렉토리 .ai.md 최신화
+- [ ] 불변식 위반 없음
+
+
+## 작업 내역
+
+### 2026-04-10
+
+**현황**: 4/4 완료
+**완료된 항목**: 전체 AC 달성
+**변경 파일**: 8개 (신규 5개, 수정 3개)
+
+**구현 내역:**
+- `apps/web/src/lib/prompts/draft-questions.ts` (신규) — Claude tool use 스키마 + buildDraftQuestionsPrompt 함수. weak_concepts 기반 4지선다 3~5개 생성 지시
+- `apps/web/src/app/api/sessions/from-draft/preview/route.ts` (신규) — AI 호출, DB 미저장. draft+insights 병렬 조회 후 Claude tool use로 문항 생성
+- `apps/web/src/app/api/sessions/from-draft/route.ts` (신규) — AI 없음, DB 트랜잭션 삽입. source session에서 subject/grade 복사, questions bulk INSERT, 실패 시 세션 롤백
+- `apps/web/src/components/dashboard/DraftSessionConfirmModal.tsx` (신규) — preview 캐시 + AbortController, 편집 가능 title, 문항 미리보기, 생성 버튼
+- `apps/web/src/components/dashboard/ClassDraftPanel.tsx` (수정) — sourceSessionId prop 추가, "AI 세션 생성" 버튼 + 모달 연결, onCreated 시 편집 페이지 라우팅
+- `apps/web/src/app/teacher/sessions/[id]/insights/page.tsx` (수정) — sourceSessionId prop 전달
+- `apps/web/src/components/dashboard/SessionDetailClient.tsx` (수정) — 👍👎 배지 및 thumbsStats 상태/useEffect 제거
+- `apps/web/src/lib/prompts/insights.ts` (수정) — parseInsightResponse에 코드 펜스 제거 처리 추가
+
+**기술적 결정:**
+- 2-step API 패턴: preview(AI 호출, 미리보기) → from-draft(DB만, 원자적 생성). `/api/class-draft/generate` 기존 계약 유지
+- Architect synthesis 채택: 마크다운 초안과 structured questions의 생명주기 분리
+

--- a/docs/work/done/000062-draft-session/01_plan.md
+++ b/docs/work/done/000062-draft-session/01_plan.md
@@ -1,0 +1,145 @@
+# [#62] feat: 수업 초안에서 다음 세션 자동 생성 — 구현 계획
+
+> 작성: 2026-04-10 | ralplan consensus (Planner → Architect → Critic)
+
+---
+
+## 완료 기준
+
+- [ ] 수업 초안 생성 후 "AI 세션 생성" 버튼이 ClassDraftPanel 하단에 표시된다
+- [ ] 버튼 클릭 시 AI가 추출한 세션 제목·문항·정답 목록을 미리 볼 수 있는 확인 모달이 열린다
+- [ ] 확인 클릭 시 세션과 문항이 자동 생성되고 편집 페이지(`/teacher/sessions/{id}/edit`)로 이동한다
+- [ ] 초안의 weak_concepts 기반으로 문항 3~5개를 자동 추출·등록한다
+
+---
+
+## 구현 계획
+
+### 설계 결정 (RALPLAN-DR)
+
+**Architect synthesis 채택** — `/api/class-draft/generate`는 기존 마크다운만 반환 유지.  
+`/api/sessions/from-draft`가 캐시된 초안을 입력으로 AI tool use → 세션+문항 트랜잭션 삽입.
+
+**이유:** 마크다운(교안)과 structured_questions(퀴즈 스키마)는 생명주기가 다름.  
+파싱 실패 격리, 재생성 유연성, 마크다운 표시 안정성 확보.
+
+**미리보기 패턴:** 2-step API
+1. `POST /api/sessions/from-draft/preview` — AI 호출, DB 미저장, 미리보기 데이터 반환
+2. `POST /api/sessions/from-draft` — AI 호출 없음, 미리보기 데이터 받아 DB 트랜잭션 삽입
+
+---
+
+### Guardrails
+
+**Must Have:**
+- `/api/class-draft/generate` 응답 기존 그대로 유지 (content 필드만, 변경 없음)
+- 문항 3~5개 검증 (Zod, 초과/미만 시 400)
+- 세션+문항 원자적 생성 (문항 삽입 실패 시 세션 롤백)
+- 소유권 체크 (teacher_id === user.id) 모든 엔드포인트
+- AI tool use / structured output으로 JSON 스키마 강제
+
+**Must NOT:**
+- 기존 `/api/sessions` POST 시그니처 변경 금지
+- `class_drafts` 테이블에 `structured_questions` 컬럼 추가 금지 (불필요)
+- `ClassDraftPanel` props 파괴적 변경 금지
+
+---
+
+### 실행 순서
+
+```
+[1] /api/sessions/from-draft/preview 엔드포인트 (AI 호출, DB 미저장)
+        ↓
+[2] /api/sessions/from-draft 엔드포인트 (AI 없음, DB 트랜잭션 삽입)
+        ↓
+[3] ClassDraftPanel UI — 버튼 + DraftSessionConfirmModal
+        ↓
+[4] 호출처 업데이트 + 타입 체크
+```
+
+---
+
+### Step 1. `/api/sessions/from-draft/preview` (AC#2, #4)
+
+**파일:**
+- `apps/web/src/app/api/sessions/from-draft/preview/route.ts` (신규)
+- `apps/web/src/lib/prompts/draft-questions.ts` (신규)
+
+**동작:**
+- Body: `{ source_session_id: uuid }`
+- 인증 + 소유권 검증
+- `class_drafts` + `ai_insights` 조회 (weak_concepts 포함)
+- Claude tool use 호출 — tool schema: `{ title: string, questions: [{content, options: [×4], correct_answer: 0..3}] }`, 문항 3~5개 강제
+- DB 저장 없이 생성된 `{ title, questions }` 반환
+
+**Acceptance:**
+- 권한 없는 사용자 → 403
+- 초안/인사이트 없는 세션 → 404
+- 응답에 title + questions 3~5개 포함
+
+---
+
+### Step 2. `/api/sessions/from-draft` (AC#3)
+
+**파일:**
+- `apps/web/src/app/api/sessions/from-draft/route.ts` (신규)
+
+**동작:**
+- Body: `{ source_session_id: uuid, title: string, questions: Question[] }`
+- 인증 + 소유권 검증 + Zod 검증 (문항 3~5개)
+- `generateUniqueJoinCode()`로 join_code 생성
+- source session에서 subject/grade 복사
+- `sessions` INSERT → `questions` bulk INSERT (question_order 0..n)
+- 문항 삽입 실패 시 세션 DELETE 후 500
+- 성공 시 `{ id }` 반환
+
+**Acceptance:**
+- 유효하지 않은 payload → 400
+- 성공 시 sessions 1개 + questions N개 생성
+- 실패 시 orphan session 없음
+
+---
+
+### Step 3. `ClassDraftPanel` UI (AC#1, #2, #3)
+
+**파일:**
+- `apps/web/src/components/dashboard/ClassDraftPanel.tsx` (수정)
+- `apps/web/src/components/dashboard/DraftSessionConfirmModal.tsx` (신규)
+
+**동작:**
+- props에 `sourceSessionId: string` 추가 (기존 `content` 유지)
+- "AI 세션 생성" 버튼 — 초안 하단에 표시
+- 버튼 클릭 → `POST /preview` 호출(로딩) → 모달 오픈
+- 모달: 편집 가능한 title + 문항 목록(정답 표시)
+- "확인" → `POST /from-draft` → `router.push('/teacher/sessions/{id}/edit')`
+- 로딩/에러 상태, 중복 클릭 방지
+
+**Acceptance:**
+- 버튼이 초안 하단에 표시됨
+- 모달에 문항 3~5개 렌더됨
+- 확인 후 편집 페이지 이동
+- 에러 시 사용자에게 메시지 표시
+
+---
+
+### Step 4. 호출처 업데이트
+
+**파일:**
+- `ClassDraftPanel` 사용처 (insights/teacher 페이지) — `sourceSessionId` prop 전달
+
+**동작:**
+- 부모 컴포넌트에서 `session.id` → `sourceSessionId`로 전달
+- 타입 체크/린트 통과 확인
+
+---
+
+## 변경 파일 목록
+
+| 파일 | 작업 |
+|------|------|
+| `apps/web/src/app/api/sessions/from-draft/preview/route.ts` | 신규 |
+| `apps/web/src/app/api/sessions/from-draft/route.ts` | 신규 |
+| `apps/web/src/lib/prompts/draft-questions.ts` | 신규 |
+| `apps/web/src/components/dashboard/ClassDraftPanel.tsx` | 수정 |
+| `apps/web/src/components/dashboard/DraftSessionConfirmModal.tsx` | 신규 |
+| `ClassDraftPanel` 사용처 (insights 페이지) | 수정 |


### PR DESCRIPTION
## 이슈 배경

수업 초안 생성 후 교사가 직접 새 세션을 만들고 문항을 수동 입력해야 하는 번거로움을 해소합니다. AI 인사이트의 weak_concepts를 기반으로 다음 수업 세션과 문항을 자동 생성해 흐름이 끊기지 않도록 합니다.

## 완료 기준 (AC)

- [x] 수업 초안 생성 후 "AI 세션 생성" 버튼이 ClassDraftPanel 하단에 표시된다
- [x] 버튼 클릭 시 AI가 추출한 세션 제목·문항·정답 목록을 미리 볼 수 있는 확인 모달이 열린다
- [x] 확인 클릭 시 세션과 문항이 자동 생성되고 편집 페이지(`/teacher/sessions/{id}/edit`)로 이동한다
- [x] 초안의 weak_concepts 기반으로 문항 3~5개를 자동 추출·등록한다

## 작업 내역

**설계 결정 — 2-step API 패턴 채택:**
- `POST /api/sessions/from-draft/preview` — AI 호출, DB 미저장. draft+insights 병렬 조회 후 Claude tool use로 문항 생성 및 미리보기 반환
- `POST /api/sessions/from-draft` — AI 없음, DB 트랜잭션 삽입. source session에서 subject/grade 복사, questions bulk INSERT, 실패 시 세션 롤백
- 기존 `/api/class-draft/generate` 계약 유지 (마크다운만 반환)

**신규 파일:**
- `apps/web/src/lib/prompts/draft-questions.ts` — Claude tool use 스키마 + 프롬프트
- `apps/web/src/app/api/sessions/from-draft/preview/route.ts` — 미리보기 엔드포인트
- `apps/web/src/app/api/sessions/from-draft/route.ts` — 세션+문항 생성 엔드포인트
- `apps/web/src/components/dashboard/DraftSessionConfirmModal.tsx` — preview 캐시 + AbortController 적용

**수정 파일:**
- `ClassDraftPanel.tsx` — "AI 세션 생성" 버튼 + 모달 연결
- `insights/page.tsx` — sourceSessionId prop 전달
- `SessionDetailClient.tsx` — 👍👎 배지 및 thumbsStats 제거
- `prompts/insights.ts` — parseInsightResponse 코드 펜스 제거 처리 추가

Closes #62